### PR TITLE
Only get the menu title if you have a menu

### DIFF
--- a/inc/components/class-menu.php
+++ b/inc/components/class-menu.php
@@ -48,11 +48,11 @@ class Menu extends Component {
 		// Get object id by location.
 		$menu_term = wp_get_nav_menu_object( $locations[ $menu_location ] ?? null );
 
-		// Get the menu title.
-		$this->config['title'] = $menu_term->name;
-
 		// If valid menu term.
 		if ( $menu_term instanceof \WP_Term ) {
+			// Get the menu title.
+			$this->config['title'] = $menu_term->name;
+
 			$this->parse_wp_menu( $menu_term );
 		}
 


### PR DESCRIPTION
Previously the menu component threw a notice when a menu wasn't configured, breaking the json output.