### PR TITLE
Add site_url as an allowed redirect

### DIFF
--- a/inc/redirects.php
+++ b/inc/redirects.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Class file for Components endpoint.
+ *
+ * @package WP_Irving
+ */
+
+namespace WP_Irving;
+
+/**
+ * Filter allowed redirect hosts to include the site_url, since only the
+ * home_url is allowed by default.
+ *
+ * @param  array $hosts An array of allowed hosts.
+ * @return array
+ */
+function allowed_redirect_hosts( $hosts ) {
+	$hosts[] = wp_parse_url( site_url(), PHP_URL_HOST );
+	return $hosts;
+}
+add_filter( 'allowed_redirect_hosts', __NAMESPACE__ . '\allowed_redirect_hosts' );

--- a/wp-irving.php
+++ b/wp-irving.php
@@ -51,6 +51,9 @@ require_once WP_IRVING_PATH . '/inc/components/class-social-share.php';
 // Integrations.
 require_once WP_IRVING_PATH . '/inc/integrations/class-safe-redirect-manager.php';
 
+// Redirects.
+require_once WP_IRVING_PATH . '/inc/redirects.php';
+
 // CLI scripts.
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	require_once WP_IRVING_PATH . '/inc/cli/class-scaffold-cli-command.php';


### PR DESCRIPTION
The `home_url` and `site_url` are not the same for Irving projects. Filter the allowed redirects to include the `site_url` too so that redirects within the admin behave correctly.