### PR TITLE
Fix the URL that should be replaced

### DIFF
--- a/inc/endpoints/class-components-endpoint.php
+++ b/inc/endpoints/class-components-endpoint.php
@@ -446,7 +446,7 @@ class Components_Endpoint extends Endpoint {
 	public static function get_wp_irving_api_url( $url ) {
 
 		// Get the path.
-		$path = str_replace( get_site_url(), '', $url );
+		$path = str_replace( get_home_url(), '', $url );
 
 		// Apply path to base components endpoint.
 		return add_query_arg(

--- a/inc/endpoints/class-data-endpoint.php
+++ b/inc/endpoints/class-data-endpoint.php
@@ -13,7 +13,7 @@ namespace WP_Irving\REST_API;
 class Data_Endpoint extends Endpoint {
 
 	/**
-	 * Attach to required hooks for form endpoint
+	 * Attach to required hooks for data endpoint.
 	 */
 	public function __construct() {
 		parent::__construct();
@@ -26,7 +26,7 @@ class Data_Endpoint extends Endpoint {
 	 */
 	public function register_rest_routes() {
 		/**
-		 * Modify the output of the components route.
+		 * Modify the output of the data route.
 		 *
 		 * @param array $data_endpoints {
 		 *     Data endpoint slugs and callback functions.

--- a/inc/endpoints/class-form-endpoint.php
+++ b/inc/endpoints/class-form-endpoint.php
@@ -26,7 +26,7 @@ class Form_Endpoint extends Endpoint {
 	 */
 	public function register_rest_routes() {
 		/**
-		 * Modify the output of the components route.
+		 * Modify the output of the forms route.
 		 *
 		 * @param array $form_endpoints {
 		 *     Form endpoint slugs and callback functions.

--- a/inc/redirects.php
+++ b/inc/redirects.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Class file for Components endpoint.
+ * Redirects.
  *
  * @package WP_Irving
  */


### PR DESCRIPTION
This fixes an error in #102 - permalinks get passed to `get_wp_irving_api_url()`, so we need to replace the `home_url`, not the `site_url` (which, granted, is often interchangeable, but makes a difference in a headless site.

Also updates some inaccurate comments.