### PR TITLE
Fix for Safe Redirect Manager

### DIFF
--- a/inc/integrations/class-safe-redirect-manager.php
+++ b/inc/integrations/class-safe-redirect-manager.php
@@ -37,6 +37,11 @@ class Safe_Redirect_Manager {
 
 		$this->srm = \SRM_Redirect::factory();
 
+		// This method is not part of Safe Redirect Manager core yet.
+		if ( ! method_exists( $this->srm, 'get_srm_redirect' ) ) {
+			return;
+		}
+
 		// Remove redirect actions from SRM.
 		remove_action( 'parse_request', [ $this->srm, 'maybe_redirect' ], 0 );
 		remove_action( 'template_redirect', [ $this->srm, 'maybe_redirect' ], 0 );

--- a/inc/integrations/class-safe-redirect-manager.php
+++ b/inc/integrations/class-safe-redirect-manager.php
@@ -31,7 +31,7 @@ class Safe_Redirect_Manager {
 	 */
 	public function __construct() {
 		// Ensure Safe Redirect Manager exists and is enabled.
-		if ( ! class_exists( '\SRM_Redirect' ) ) {
+		if ( ! class_exists( '\SRM_Redirect' ) || ! method_exists( '\SRM_Redirect', 'get_srm_redirect' ) ) {
 			return;
 		}
 
@@ -63,12 +63,7 @@ class Safe_Redirect_Manager {
 		add_filter( 'srm_redirect_to', [ $this, 'set_srm_redirect_to' ] );
 
 		// Find matching redirect for current path.
-
-		if ( method_exists( $this->srm, 'get_srm_redirect' ) ) {
-			$redirect_match = $this->srm->get_redirect_match();
-		} else {
-			$redirect_match = [];
-		}
+		$redirect_match = $this->srm->get_redirect_match();
 
 		// Add redirect_to and status_code from SRM match.
 		$data['redirectTo'] = empty( $data['redirectTo'] ) ?

--- a/inc/integrations/class-safe-redirect-manager.php
+++ b/inc/integrations/class-safe-redirect-manager.php
@@ -37,11 +37,6 @@ class Safe_Redirect_Manager {
 
 		$this->srm = \SRM_Redirect::factory();
 
-		// This method is not part of Safe Redirect Manager core yet.
-		if ( ! method_exists( $this->srm, 'get_srm_redirect' ) ) {
-			return;
-		}
-
 		// Remove redirect actions from SRM.
 		remove_action( 'parse_request', [ $this->srm, 'maybe_redirect' ], 0 );
 		remove_action( 'template_redirect', [ $this->srm, 'maybe_redirect' ], 0 );
@@ -68,7 +63,12 @@ class Safe_Redirect_Manager {
 		add_filter( 'srm_redirect_to', [ $this, 'set_srm_redirect_to' ] );
 
 		// Find matching redirect for current path.
-		$redirect_match = $this->srm->get_redirect_match();
+
+		if ( method_exists( $this->srm, 'get_srm_redirect' ) ) {
+			$redirect_match = $this->srm->get_redirect_match();
+		} else {
+			$redirect_match = [];
+		}
 
 		// Add redirect_to and status_code from SRM match.
 		$data['redirectTo'] = empty( $data['redirectTo'] ) ?

--- a/inc/integrations/class-safe-redirect-manager.php
+++ b/inc/integrations/class-safe-redirect-manager.php
@@ -31,7 +31,7 @@ class Safe_Redirect_Manager {
 	 */
 	public function __construct() {
 		// Ensure Safe Redirect Manager exists and is enabled.
-		if ( ! class_exists( '\SRM_Redirect' ) || ! method_exists( '\SRM_Redirect', 'get_srm_redirect' ) ) {
+		if ( ! class_exists( '\SRM_Redirect' ) || ! method_exists( '\SRM_Redirect', 'get_redirect_match' ) ) {
 			return;
 		}
 

--- a/tests/test-safe-redirect-manager.php
+++ b/tests/test-safe-redirect-manager.php
@@ -31,10 +31,22 @@ class Safe_Redirect_Manager_Tests extends WP_UnitTestCase {
 		self::$helpers = new \WP_Irving\Test_Helpers();
 	}
 
+	public function setUp() {
+		parent::setUp();
+
+		$this->object = \SRM_Redirect::factory();
+	}
+
 	/**
 	 * Test relative redirect.
 	 */
 	public function test_relative_to_relative() {
+		if ( ! method_exists( $this->object, 'get_redirect_match' ) ) {
+			$this->markTestIncomplete(
+				'get_redirect_match not part of Safe Redirect Manager.'
+			);
+		}
+
 		srm_create_redirect( '/foo/', '/bar/' );
 		$response = self::$helpers->get_components_endpoint_response( '/foo/' );
 		$this->assertEquals( 'http://example.org/bar/', $response->data['redirectTo'] );
@@ -44,6 +56,12 @@ class Safe_Redirect_Manager_Tests extends WP_UnitTestCase {
 	 * Test redirects from a relative URL to an absolute URL.
 	 */
 	public function test_relative_to_absolute() {
+		if ( ! method_exists( $this->object, 'get_redirect_match' ) ) {
+			$this->markTestIncomplete(
+				'get_redirect_match not part of Safe Redirect Manager.'
+			);
+		}
+
 		// Internal, absolute URL destination.
 		srm_create_redirect( '/foo/bar/', 'http://example.org/baz/' );
 		$response = self::$helpers->get_components_endpoint_response( '/foo/bar/' );
@@ -59,6 +77,12 @@ class Safe_Redirect_Manager_Tests extends WP_UnitTestCase {
 	 * Test redirects from an absolute, internal URL to a relative URL.
 	 */
 	public function test_absolute_to_relative() {
+		if ( ! method_exists( $this->object, 'get_redirect_match' ) ) {
+			$this->markTestIncomplete(
+				'get_redirect_match not part of Safe Redirect Manager.'
+			);
+		}
+
 		srm_create_redirect( 'http://example.org/foo/', '/bar/' );
 		$response = self::$helpers->get_components_endpoint_response( '/foo/' );
 		$this->assertEquals( 'http://example.org/bar/', $response->data['redirectTo'] );
@@ -68,6 +92,12 @@ class Safe_Redirect_Manager_Tests extends WP_UnitTestCase {
 	 * Test redirects from one absolute URL to another.
 	 */
 	public function test_absolute_to_absolute() {
+		if ( ! method_exists( $this->object, 'get_redirect_match' ) ) {
+			$this->markTestIncomplete(
+				'get_redirect_match not part of Safe Redirect Manager.'
+			);
+		}
+
 		// Internal, absolute URL destination.
 		srm_create_redirect( 'http://example.org/foo/bar/', 'http://example.org/baz/' );
 		$response = self::$helpers->get_components_endpoint_response( '/foo/bar/' );
@@ -83,6 +113,12 @@ class Safe_Redirect_Manager_Tests extends WP_UnitTestCase {
 	 * Test redirect_from URLs with and without a trailling slash will still match.
 	 */
 	public function test_trailing_slashes() {
+		if ( ! method_exists( $this->object, 'get_redirect_match' ) ) {
+			$this->markTestIncomplete(
+				'get_redirect_match not part of Safe Redirect Manager.'
+			);
+		}
+
 		// Redirect from with trailing slash.
 		srm_create_redirect( '/trailing-slash/', '/destination/' );
 

--- a/tests/test-safe-redirect-manager.php
+++ b/tests/test-safe-redirect-manager.php
@@ -25,6 +25,13 @@ class Safe_Redirect_Manager_Tests extends WP_UnitTestCase {
 	static $components_endpoint;
 
 	/**
+	 * Holding the SRM object.
+	 *
+	 * @var SRM_Redirect
+	 */
+	public $object;
+
+	/**
 	 * Test suite setup.
 	 */
 	public static function setUpBeforeClass() {
@@ -41,11 +48,7 @@ class Safe_Redirect_Manager_Tests extends WP_UnitTestCase {
 	 * Test relative redirect.
 	 */
 	public function test_relative_to_relative() {
-		if ( ! method_exists( $this->object, 'get_redirect_match' ) ) {
-			$this->markTestIncomplete(
-				'get_redirect_match not part of Safe Redirect Manager.'
-			);
-		}
+		$this->markasIncomplete();
 
 		srm_create_redirect( '/foo/', '/bar/' );
 		$response = self::$helpers->get_components_endpoint_response( '/foo/' );
@@ -56,11 +59,7 @@ class Safe_Redirect_Manager_Tests extends WP_UnitTestCase {
 	 * Test redirects from a relative URL to an absolute URL.
 	 */
 	public function test_relative_to_absolute() {
-		if ( ! method_exists( $this->object, 'get_redirect_match' ) ) {
-			$this->markTestIncomplete(
-				'get_redirect_match not part of Safe Redirect Manager.'
-			);
-		}
+		$this->markasIncomplete();
 
 		// Internal, absolute URL destination.
 		srm_create_redirect( '/foo/bar/', 'http://example.org/baz/' );
@@ -77,11 +76,7 @@ class Safe_Redirect_Manager_Tests extends WP_UnitTestCase {
 	 * Test redirects from an absolute, internal URL to a relative URL.
 	 */
 	public function test_absolute_to_relative() {
-		if ( ! method_exists( $this->object, 'get_redirect_match' ) ) {
-			$this->markTestIncomplete(
-				'get_redirect_match not part of Safe Redirect Manager.'
-			);
-		}
+		$this->markasIncomplete();
 
 		srm_create_redirect( 'http://example.org/foo/', '/bar/' );
 		$response = self::$helpers->get_components_endpoint_response( '/foo/' );
@@ -92,11 +87,7 @@ class Safe_Redirect_Manager_Tests extends WP_UnitTestCase {
 	 * Test redirects from one absolute URL to another.
 	 */
 	public function test_absolute_to_absolute() {
-		if ( ! method_exists( $this->object, 'get_redirect_match' ) ) {
-			$this->markTestIncomplete(
-				'get_redirect_match not part of Safe Redirect Manager.'
-			);
-		}
+		$this->markasIncomplete();
 
 		// Internal, absolute URL destination.
 		srm_create_redirect( 'http://example.org/foo/bar/', 'http://example.org/baz/' );
@@ -113,11 +104,7 @@ class Safe_Redirect_Manager_Tests extends WP_UnitTestCase {
 	 * Test redirect_from URLs with and without a trailling slash will still match.
 	 */
 	public function test_trailing_slashes() {
-		if ( ! method_exists( $this->object, 'get_redirect_match' ) ) {
-			$this->markTestIncomplete(
-				'get_redirect_match not part of Safe Redirect Manager.'
-			);
-		}
+		$this->markasIncomplete();
 
 		// Redirect from with trailing slash.
 		srm_create_redirect( '/trailing-slash/', '/destination/' );
@@ -140,5 +127,13 @@ class Safe_Redirect_Manager_Tests extends WP_UnitTestCase {
 		// Request without trailing slash.
 		$response = self::$helpers->get_components_endpoint_response( '/trailing-slash' );
 		$this->assertEquals( 'http://example.org/destination/', $response->data['redirectTo'] );
+	}
+
+	public function markasIncomplete() {
+		if ( ! method_exists( $this->object, 'get_redirect_match' ) ) {
+			$this->markTestIncomplete(
+				'get_redirect_match not part of Safe Redirect Manager.'
+			);
+		}
 	}
 }


### PR DESCRIPTION
Sites that have the Safe Redirect Manager plugin activated but without this part/PR, https://github.com/10up/safe-redirect-manager/pull/176, applied fails. Meaning the endpoint fails because the method doesn't exist yet.

This PR fixes the fatal error. As soon as the PR is applied to the plugin, we can remove it.