### PR TITLE
Avoid endpoint error

### DIFF
--- a/inc/integrations/class-yoast.php
+++ b/inc/integrations/class-yoast.php
@@ -199,6 +199,11 @@ class Yoast {
 		global $wp_query;
 		$wp_query->is_singular = true;
 
+		// Only if the method exists.
+		if ( ! method_exists( '\WPSEO_Frontend', 'get_robots' ) ) {
+			return '';
+		}
+
 		$deindex = \WPSEO_Frontend::get_instance()->get_robots();
 		return strpos( $deindex, 'noindex' ) !== false;
 	}


### PR DESCRIPTION
On version 11.4 of Yoast, this method doesn't exist. Which is breaking the Irving endpoint.

So let's avoid the error if possible.