### PR TITLE
Fire redirect integration filters earlier than default 10

### DIFF
--- a/inc/integrations/class-safe-redirect-manager.php
+++ b/inc/integrations/class-safe-redirect-manager.php
@@ -42,7 +42,7 @@ class Safe_Redirect_Manager {
 		remove_action( 'template_redirect', [ $this->srm, 'maybe_redirect' ], 0 );
 
 		// Re-use SRM's filter to redirect only on 404s.
-		add_filter( 'wp_irving_components_route', [ $this, 'get_srm_redirect' ], 10, 5 );
+		add_filter( 'wp_irving_components_route', [ $this, 'get_srm_redirect' ], 5, 5 );
 	}
 
 	/**

--- a/inc/integrations/class-wpcom-legacy-redirector.php
+++ b/inc/integrations/class-wpcom-legacy-redirector.php
@@ -28,7 +28,7 @@ class WPCOM_Legacy_Redirector {
 		}
 
 		// Handle Irving redirects.
-		add_action( 'wp_irving_components_route', [ $this, 'handle_redirect' ], 10, 5 );
+		add_filter( 'wp_irving_components_route', [ $this, 'handle_redirect' ], 5, 5 );
 	}
 
 	/**

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -28,7 +28,10 @@
 	<exclude-pattern>inc/cli.php</exclude-pattern>
 	<exclude-pattern>tests/</exclude-pattern>
 
-	<rule ref="WordPress" />
+	<!-- Include the WordPress ruleset, with exclusions. -->
+	<rule ref="WordPress">
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found" />
+	</rule>
 
 	<!-- The version set here matches the minimum version tested in .travis.yml.  -->
 	<config name="minimum_supported_wp_version" value="4.9" />


### PR DESCRIPTION
Since themes are likely to use priority 10 for their `wp_irving_components_route` filter, it's useful to ensure our WPCOM Legacy Redirector and Safe Redirect Manager integration filters have fired before 10 and therefore set the redirect URL and redirect status if appropriate before a theme's routing filter fires.

Also, fix PHPCS rule