### PR TITLE
Revert a bad commit and offer an alternative solution

### DIFF
--- a/inc/endpoints/class-components-endpoint.php
+++ b/inc/endpoints/class-components-endpoint.php
@@ -302,33 +302,31 @@ class Components_Endpoint extends Endpoint {
 			}
 		}
 
-		// Fix an issue where `add_query_arg` doesn't work with already
-		// encoded strings missing the equal.
 		if ( ! empty( $query ) ) {
+
+			// Fix an issue where `add_query_arg` doesn't work with already
+			// encoded strings missing the equal.
 			if ( false === strpos( $query, '=' ) ) {
 				$query .= '=';
 			}
+
+			// Add irving-path to the query.
+			$query = add_query_arg(
+				[
+					'irving-path'   => $this->path,
+					'irving-path-params' => $this->custom_params,
+				],
+				$query
+			);
+
+			// Add any extra included params.
+			foreach ( $this->custom_params as $key => $value ) {
+				$query = add_query_arg( $key, $value, $query );
+			}
+
+			// add_query_arg will encode the url, which we don't want.
+			$query = urldecode( $query );
 		}
-
-		// Add irving-path to the query.
-		$query = add_query_arg(
-			[
-				'irving-path'        => $this->path,
-				'irving-path-params' => $this->custom_params,
-			],
-			$query
-		);
-
-		// Add any extra included params.
-		foreach ( $this->custom_params as $key => $value ) {
-			$query = add_query_arg( $key, $value, $query );
-		}
-
-		// Add_query_arg will encode the url, which we don't want.
-		$query = urldecode( $query );
-
-		// Remove any leading question marks as artifacts from add_query_arg.
-		$query = ltrim( $query, '?' );
 
 		/**
 		 * Modify the query vars.

--- a/inc/endpoints/class-components-endpoint.php
+++ b/inc/endpoints/class-components-endpoint.php
@@ -20,6 +20,13 @@ class Components_Endpoint extends Endpoint {
 	public $path = '';
 
 	/**
+	 * Static version of the path for accessing globally.
+	 *
+	 * @var string
+	 */
+	public static $irving_path = '';
+
+	/**
 	 * Context of request.
 	 *
 	 * @var string
@@ -205,7 +212,8 @@ class Components_Endpoint extends Endpoint {
 		 *
 		 * @param  string $raw_path Raw path value from request.
 		 */
-		$this->path = (string) apply_filters( 'wp_irving_components_path', $raw_path );
+		$this->path        = (string) apply_filters( 'wp_irving_components_path', $raw_path );
+		self::$irving_path = $this->path;
 
 		/**
 		 * Action fired on the sanitized path value.


### PR DESCRIPTION
See https://alleyinteractive.atlassian.net/browse/IRV-298

Originally we updated the logic in the component endpoint to always include the `irving-path` value, however this borks things, so we're undoing it, and implementing a static var with the value of the path that can be accessed from anywhere.