### PR TITLE
Feature/irv 308/jwt auth

### DIFF
--- a/inc/class-previews.php
+++ b/inc/class-previews.php
@@ -47,7 +47,7 @@ class Previews {
 		remove_action( 'init', '_show_post_preview' );
 
 		// Filter to enable/disable public previews.
-		if ( apply_filters( 'wp_irving_enable_public_previews', true ) ) {
+		if ( apply_filters( 'wp_irving_enable_public_previews', false ) ) {
 			add_action( 'wp_irving_components_request', [ $this, 'enabled_public_previews' ] );
 		}
 

--- a/inc/class-previews.php
+++ b/inc/class-previews.php
@@ -135,7 +135,7 @@ class Previews {
 			return $wp_query;
 		}
 
-		// Get all the revisions
+		// Get all the revisions.
 		$revisions = wp_get_post_revisions( $wp_query->post->ID );
 
 		// Use the preview_id, or fallback to the most recent revision.

--- a/inc/class-previews.php
+++ b/inc/class-previews.php
@@ -42,18 +42,25 @@ class Previews {
 		add_filter( 'query_vars', [ $this, 'modify_query_vars' ] );
 
 		// Filter to easily enable public previews.
-		if ( apply_filters( 'wp_irving_enable_public_previews', '__return_false' ) ) {
+		if ( apply_filters( 'wp_irving_enable_public_previews', false ) ) {
 			$this->enable_public_previews();
 		}
 
-		// Validate that JWT exists and is enabled.
-		if ( ! defined( 'JWT_AUTH_VERSION' ) ) {
-			return;
-		}
+		// After plugins have loaded, check for JWT and modify the preview logic as needed.
+		add_action(
+			'plugins_loaded',
+			function() {
 
-		// Hook into Irving's query string to WP_Query process to modify some
-		// logic for previews.
-		add_action( 'wp_irving_components_wp_query', [ $this, 'modify_wp_query_for_previews' ], 10, 4 );
+				// Validate that JWT exists and is enabled.
+				if ( ! defined( 'JWT_AUTH_VERSION' ) ) {
+					return;
+				}
+
+				// Hook into Irving's query string to WP_Query process to modify some
+				// logic for previews.
+				// add_action( 'wp_irving_components_wp_query', [ $this, 'modify_wp_query_for_previews' ], 10, 4 );
+			}
+		);
 	}
 
 	/**

--- a/inc/class-previews.php
+++ b/inc/class-previews.php
@@ -61,8 +61,6 @@ class Previews {
 					return;
 				}
 
-				add_action( 'wp_irving_components_request', [ $this, 'check_for_previews' ] );
-
 				// Hook into Irving's components request to check if it's for a preview.
 				add_action( 'wp_irving_components_request', [ $this, 'check_for_previews' ] );
 			}
@@ -77,7 +75,6 @@ class Previews {
 	 */
 	public function modify_query_vars( array $vars ): array {
 		$vars[] = 'preview_id';
-		// $vars[] = '_thumbnail_id';
 		$vars[] = 'preview_nonce';
 		return $vars;
 	}

--- a/inc/class-previews.php
+++ b/inc/class-previews.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Replicating core WP previews for Irving.
+ *
+ * @package WP_Irving
+ */
+
+namespace WP_Irving;
+
+/**
+ * Singleton class for customizing core's preview logic as needed to work with
+ * Irving.
+ */
+class Previews {
+
+	/**
+	 * Class instance.
+	 *
+	 * @var null|self
+	 */
+	protected static $instance;
+
+	/**
+	 * Get class instance
+	 *
+	 * @return self
+	 */
+	public static function instance() {
+		if ( ! isset( static::$instance ) ) {
+			static::$instance = new static();
+			static::$instance->setup();
+		}
+		return static::$instance;
+	}
+
+	/**
+	 * Setup the singleton. Validate JWT is installed, and setup hooks.
+	 */
+	public function setup() {
+
+		// Allow-list some query vars.
+		add_filter( 'query_vars', [ $this, 'modify_query_vars' ] );
+
+		// Filter to easily enable public previews.
+		if ( apply_filters( 'wp_irving_enable_public_previews', '__return_false' ) ) {
+			$this->enable_public_previews();
+		}
+
+		// Validate that JWT exists and is enabled.
+		if ( ! defined( 'JWT_AUTH_VERSION' ) ) {
+			return;
+		}
+
+		// Hook into Irving's query string to WP_Query process to modify some
+		// logic for previews.
+		add_action( 'wp_irving_components_wp_query', [ $this, 'modify_wp_query_for_previews' ], 10, 4 );
+	}
+
+	/**
+	 * Allow-list some query vars for previews.
+	 *
+	 * @param  array $vars Allow-listed query vars.
+	 * @return array
+	 */
+	public function modify_query_vars( array $vars ): array {
+		$vars[] = 'preview_id';
+		$vars[] = 'preview_nonce';
+		return $vars;
+	}
+
+	/**
+	 * Enable public previews.
+	 */
+	public function enable_public_previews() {
+
+		// Disable revision preview nonces.
+		remove_action( 'init', '_show_post_preview' );
+
+		// Hook into the component API request and change the draft preview
+		// to be `publish`, mimicking a public post.
+		add_filter(
+			'wp_irving_components_request',
+			function ( $request ) {
+				if (
+					true === (bool) $request->get_param( 'preview' )
+					|| 0 !== absint( $request->get_param( 'p' ) )
+				) {
+					add_filter(
+						'posts_results',
+						function ( $posts ) {
+
+							if ( empty( $posts ) ) {
+								return $posts;
+							}
+
+							$posts[0]->post_status = 'publish';
+							return $posts;
+						}
+					);
+				}
+
+			}
+		);
+	}
+
+	/**
+	 * Modify the \WP_Query object that Irving creates to swap out the published post, for the correct revision.
+	 *
+	 * @param \WP_Query $wp_query      WP_Query object corresponding to this
+	 *                                 request.
+	 * @param string    $path          Request path.
+	 * @param string    $custom_params Custom params.
+	 * @param string    $params        Request params.
+	 * @return \WP_Qury $wp_query WP_Query object for the request.
+	 */
+	public function modify_wp_query_for_previews( $wp_query, $path, $custom_params, $params ) {
+
+		// Disable revision preview nonces so we can inject our own logic.
+		// Without this, wp_die() will execute, which means our auth strategy
+		// fails. There isn't anyway to currently filter this behavior, so
+		// we're stuck with this.
+		remove_action( 'init', '_show_post_preview' );
+
+		// Auth and a real route required.
+		if ( ! is_user_logged_in() || ! $wp_query->have_posts() ) {
+			return $wp_query;
+		}
+
+		$is_preview = wp_validate_boolean( $params['preview'] ?? false );
+		$preview_id = absint( $params['preview_id'] ?? 0 );
+
+		// This is not a preview.
+		if (
+			false === $is_preview
+			|| 0 === $preview_id
+		) {
+			return $wp_query;
+		}
+
+		if ( ( $wp_query->post->ID ?? 0 ) === $preview_id ) {
+			$revision = array_shift( wp_get_post_revisions( $preview_id ) );
+		} else {
+			$revision = wp_get_post_revision( $preview_id );
+		}
+
+		$wp_query->posts[0] = $revision;
+		$wp_query->post     = $revision;
+
+		return $wp_query;
+	}
+}
+
+( new \WP_Irving\Previews() )->instance();

--- a/inc/class-previews.php
+++ b/inc/class-previews.php
@@ -130,7 +130,7 @@ class Previews {
 		$is_preview = wp_validate_boolean( $params['preview'] ?? false );
 		$preview_id = absint( $params['preview_id'] ?? 0 );
 
-		// Require `preview` to be true, and `p` to be an integer.
+		// Require `preview` to be true, and `preview_id` to be an integer.
 		if ( false === $is_preview || 0 === $preview_id ) {
 			return $wp_query;
 		}

--- a/inc/class-previews.php
+++ b/inc/class-previews.php
@@ -63,7 +63,7 @@ class Previews {
 
 				// Hook into Irving's query string to WP_Query process to modify some
 				// logic for previews.
-				add_action( 'wp_irving_components_wp_query', [ $this, 'modify_wp_query_for_previews' ], 10, 4 );
+				add_action( 'wp_irving_components_wp_query', [ $this, 'modify_wp_query_for_revisions' ], 10, 4 );
 			}
 		);
 	}
@@ -120,7 +120,7 @@ class Previews {
 	 * @param string    $params        Request params.
 	 * @return \WP_Qury $wp_query WP_Query object for the request.
 	 */
-	public function modify_wp_query_for_previews( $wp_query, $path, $custom_params, $params ) {
+	public function modify_wp_query_for_revisions( $wp_query, $path, $custom_params, $params ) {
 
 		// Auth and a real route required.
 		if ( ! is_user_logged_in() || ! $wp_query->have_posts() ) {
@@ -141,8 +141,42 @@ class Previews {
 		// Use the preview_id, or fallback to the most recent revision.
 		$revision = $revisions[ $preview_id ] ?? current( $revisions );
 
-		$wp_query->posts[0] = $revision;
-		$wp_query->post     = $revision;
+		/**
+		 * Determine which revision fields should override the published post.
+		 * WP Core supports title, content, and excerpt by default.
+		 *
+		 * @var array     Keys to merge from the revision post into the published
+		 *                parent post.
+		 * @var \WP_Query The WP_Query object for Irving.
+		 * @var \WP_Post  WP_Post object for the current revision.
+		 * @var \WP_Post  Array of all revisions for this post.
+		 * @return array
+		 */
+		$keys_to_merge = apply_filters(
+			'wp_irving_preview_revision_keys',
+			[ 'post_title', 'post_content', 'post_excerpt' ],
+			$wp_query,
+			$revision,
+			$revisions
+		);
+
+		foreach ( $keys_to_merge as $key ) {
+			if ( isset( $revision->$key ) ) {
+				$wp_query->posts[0]->$key = $revision->$key; // phpcs:ignore Squiz.PHP.DisallowMultipleAssignments.Found
+				$wp_query->post->$key     = $revision->$key;
+			}
+		}
+
+		/**
+		 * Allow filtering of the wp_query after all other revision logic has
+		 * ran.
+		 *
+		 * @param \WP_Query The WP_Query object for Irving.
+		 * @param \WP_Post  WP_Post object for the current revision.
+		 * @param \WP_Post  Array of all revisions for this post.
+		 * @return \WP_Query
+		 */
+		$wp_query = apply_filters( 'wp_irving_preview_revision_wp_query', $wp_query, $revision, $revisions );
 
 		return $wp_query;
 	}

--- a/inc/endpoints/class-components-endpoint.php
+++ b/inc/endpoints/class-components-endpoint.php
@@ -132,6 +132,7 @@ class Components_Endpoint extends Endpoint {
 	 */
 	public function get_route_response( $request ) {
 
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited
 		global $wp;
 
 		/**
@@ -145,7 +146,7 @@ class Components_Endpoint extends Endpoint {
 		// global $wp object's $public_query_vars array.
 		$this->params = array_intersect_key(
 			$request->get_params(),
-			array_flip( $wp->public_query_vars ),
+			array_flip( $wp->public_query_vars )
 		);
 
 		// Parse path and context.
@@ -374,7 +375,7 @@ class Components_Endpoint extends Endpoint {
 		$wp_query = apply_filters( 'wp_irving_components_wp_query', $wp_query, $this->path, $this->custom_params, $this->params );
 
 		// Map to main query and set up globals.
-		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited, WordPress.WP.GlobalVariablesOverride.OverrideProhibited
 		$wp_the_query = $wp_query;
 		$this->register_globals();
 
@@ -404,7 +405,7 @@ class Components_Endpoint extends Endpoint {
 	 * @see https://github.com/WordPress/WordPress/blob/master/wp-includes/class-wp.php#L580
 	 */
 	public function register_globals() {
-		// phpcs:disable WordPress.WP.GlobalVariablesOverride.Prohibited
+		// phpcs:disable WordPress.WP.GlobalVariablesOverride.Prohibited, WordPress.WP.GlobalVariablesOverride.OverrideProhibited
 		global $wp_the_query, $wp_query;
 		$wp_query = $wp_the_query;
 

--- a/inc/endpoints/class-components-endpoint.php
+++ b/inc/endpoints/class-components-endpoint.php
@@ -131,6 +131,9 @@ class Components_Endpoint extends Endpoint {
 	 * @return array
 	 */
 	public function get_route_response( $request ) {
+
+		global $wp;
+
 		/**
 		 * Action fired on the request.
 		 *
@@ -138,7 +141,12 @@ class Components_Endpoint extends Endpoint {
 		 */
 		do_action( 'wp_irving_components_request', $request );
 
-		$this->params = $request->get_params();
+		// Remove any request parameters that haven't been allow-listed by the
+		// global $wp object's $public_query_vars array.
+		$this->params = array_intersect_key(
+			$request->get_params(),
+			array_flip( $wp->public_query_vars ),
+		);
 
 		// Parse path and context.
 		$this->parse_path( $this->params['path'] ?? '' );
@@ -442,6 +450,8 @@ class Components_Endpoint extends Endpoint {
 	 * @return array $vars Array of query vars.
 	 */
 	public function modify_query_vars( $vars ) {
+		$vars[] = 'context';
+		$vars[] = 'path';
 		$vars[] = 'irving-path';
 		$vars[] = 'irving-path-params';
 		return $vars;

--- a/inc/integrations/class-jwt-auth.php
+++ b/inc/integrations/class-jwt-auth.php
@@ -16,7 +16,7 @@ class JWT_Auth {
 	 *
 	 * @var string
 	 */
-	const COOKIE_NAME = 'authorizationHeader';
+	const COOKIE_NAME = 'authorizationBearerToken';
 
 	/**
 	 * Name for the keypair.

--- a/inc/integrations/class-jwt-auth.php
+++ b/inc/integrations/class-jwt-auth.php
@@ -215,4 +215,9 @@ class JWT_Auth {
 	}
 }
 
-( new \WP_Irving\JWT_Auth() )->instance();
+add_action(
+	'plugins_loaded',
+	function() {
+		( new \WP_Irving\JWT_Auth() )->instance();
+	}
+);

--- a/inc/integrations/class-jwt-auth.php
+++ b/inc/integrations/class-jwt-auth.php
@@ -60,10 +60,17 @@ class JWT_Auth {
 		// Set or unset the cookie upon init.
 		add_action( 'init', [ $this, 'handle_cookie' ] );
 
-		// Don't require the token to be valid. This ensures that even if the
-		// value of the cookie is an invalid token, the unauthenticated
-		// endpoint is returned rather than an error message.
-		add_filter( 'rest_authentication_require_token', '__return_false' );
+		// Return the API result instead of an invalid token error. This
+		// ensures invalid tokens don't error out, and instead get the
+		// non-authenticated components API.
+		add_filter(
+			'rest_authentication_invalid_token',
+			function( $token, $result ) {
+				return $result;
+			},
+			10,
+			2
+		);
 	}
 
 	/**

--- a/inc/integrations/class-jwt-auth.php
+++ b/inc/integrations/class-jwt-auth.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Previews.
+ *
+ * This functionality ensures that authenticated previews still work in Irving.
+ *
+ * @package WP_Irving
+ */
+
+namespace WP_Irving;
+
+class JWT_Auth {
+
+	/**
+	 * Cookie name that Irving core expects.
+	 *
+	 * @var string
+	 */
+	const COOKIE_NAME = 'authorizationHeader';
+
+	/**
+	 * Name for the keypair.
+	 *
+	 * @var string
+	 */
+	const KEYPAIR_NAME = 'wp-irving-jwt-auth';
+
+	/**
+	 * Class instance.
+	 *
+	 * @var null|self
+	 */
+	protected static $instance;
+
+	/**
+	 * Get class instance
+	 *
+	 * @return self
+	 */
+	public static function instance() {
+		if ( ! isset( static::$instance ) ) {
+			static::$instance = new static();
+			static::$instance->setup();
+		}
+		return static::$instance;
+	}
+
+	/**
+	 * Setup the singleton.
+	 *
+	 * @todo Determine if we need to validate the token. This may not be needed
+	 * because the cookie is set to expire right before the auth token does.
+	 * Maybe we should hook into if/when the token is revoked so we can kill
+	 * the cookie too?
+	 */
+	public function setup() {
+		if ( ! isset( $_COOKIE[ self::COOKIE_NAME ] ) ) {
+			add_action( 'admin_init', [ $this, 'set_cookie' ] );
+		} else {
+			add_action( 'init', [ $this, 'remove_cookie' ] );
+		}
+	}
+
+	/**
+	 * Get a clean token and set the cookie.
+	 */
+	public function set_cookie() {
+		$token_response = $this->get_or_create_token();
+		setcookie( self::COOKIE_NAME, $token_response['access_token'], time() + ( DAY_IN_SECONDS * 7 ) - MINUTE_IN_SECONDS, '/', IRVING_TLD, TRUE, FALSE );
+	}
+
+	/**
+	 * If the user isn't logged in, ensure the auth cookie is deleted.
+	 */
+	public function remove_cookie() {
+		if ( ! is_user_logged_in() ) {
+			setcookie( self::COOKIE_NAME, null, -1, '/', IRVING_TLD );
+		}
+	}
+
+	/**
+	 * [get_or_create_wp_irving_preview_token description]
+	 * @return [type] [description]
+	 */
+	public function get_or_create_token() {
+
+		$user_id    = get_current_user_id();
+		$api_key    = $user_id . wp_generate_password( 24, false );
+		$api_secret = wp_generate_password( 32 );
+
+		/**
+		 * Here are saving the new keypairs. This information is important
+		 * in case the user wishes to remove the token validation via their user profile.
+		 */
+		$wp_rest_keypair = new \WP_REST_Key_Pair();
+		$keypairs        = $wp_rest_keypair->get_user_key_pairs( $user_id );
+
+		// Delete any existing keypairs.
+		foreach ( $keypairs as $index => $keypair ) {
+			if ( $keypair['name'] === self::KEYPAIR_NAME ) {
+				unset( $keypairs[ $index ] );
+			}
+		}
+
+		$keypairs[]      = [
+			'name'       => self::KEYPAIR_NAME,
+			'api_key'    => $api_key,
+			'api_secret' => wp_hash( $api_secret ),
+			'created'    => time(),
+			'last_used'  => null,
+			'last_ip'    => null,
+		];
+
+		// Saving the new key.
+		$keys = (array) $wp_rest_keypair->set_user_key_pairs( $user_id, $keypairs );
+
+		// Set the new request with the new key and secret.
+		$token_request = new \WP_REST_Request( \WP_REST_Server::CREATABLE, '/wp/v2/token' );
+		$token_request->set_query_params(
+			[
+				'api_key'    => $api_key,
+				'api_secret' => $api_secret,
+			]
+		);
+
+		// Let's get the token.
+		$token_request = rest_do_request( $token_request );
+
+		if ( 200 === $token_request->status ?? 0 ) {
+			return $token_request->data;
+		}
+
+		return false;
+	}
+}
+
+( new \WP_Irving\JWT_Auth() )->instance();

--- a/wp-irving.php
+++ b/wp-irving.php
@@ -37,7 +37,8 @@ require_once WP_IRVING_PATH . '/inc/integrations/class-vip-go.php';
 require_once WP_IRVING_PATH . '/inc/integrations/class-wpcom-legacy-redirector.php';
 require_once WP_IRVING_PATH . '/inc/integrations/class-yoast.php';
 
-// Purge Cache.
+// Replicating WP Core functionality.
+require_once WP_IRVING_PATH . '/inc/class-previews.php';
 require_once WP_IRVING_PATH . '/inc/class-purge-cache.php';
 
 // Redirects.

--- a/wp-irving.php
+++ b/wp-irving.php
@@ -28,19 +28,20 @@ require_once WP_IRVING_PATH . '/inc/endpoints/class-data-endpoint.php';
 require_once WP_IRVING_PATH . '/inc/endpoints/class-form-endpoint.php';
 
 // Integrations.
-require_once WP_IRVING_PATH . '/inc/integrations/class-wpcom-legacy-redirector.php';
-require_once WP_IRVING_PATH . '/inc/integrations/class-safe-redirect-manager.php';
-require_once WP_IRVING_PATH . '/inc/integrations/class-google-amp.php';
 require_once WP_IRVING_PATH . '/inc/integrations/class-archiveless.php';
-require_once WP_IRVING_PATH . '/inc/integrations/class-vip-go.php';
-require_once WP_IRVING_PATH . '/inc/integrations/class-yoast.php';
+require_once WP_IRVING_PATH . '/inc/integrations/class-google-amp.php';
+require_once WP_IRVING_PATH . '/inc/integrations/class-jwt-auth.php';
 require_once WP_IRVING_PATH . '/inc/integrations/class-new-relic.php';
-
-// Redirects.
-require_once WP_IRVING_PATH . '/inc/redirects.php';
+require_once WP_IRVING_PATH . '/inc/integrations/class-safe-redirect-manager.php';
+require_once WP_IRVING_PATH . '/inc/integrations/class-vip-go.php';
+require_once WP_IRVING_PATH . '/inc/integrations/class-wpcom-legacy-redirector.php';
+require_once WP_IRVING_PATH . '/inc/integrations/class-yoast.php';
 
 // Purge Cache.
 require_once WP_IRVING_PATH . '/inc/class-purge-cache.php';
+
+// Redirects.
+require_once WP_IRVING_PATH . '/inc/redirects.php';
 
 // Rewrite rules.
 require_once WP_IRVING_PATH . '/inc/rewrites.php';


### PR DESCRIPTION
Adds a new integration for the WP-API/JWT auth plugin.

This creates a new Bearer token to be used in Authentication headers, and is cross-domain, so Irving core can use it.

See https://github.com/alleyinteractive/irving/tree/feature/IRV-313/components-api-auth for the companion update in Irving core.