### PR TITLE
Add initial template loading logic to components endpoint

### DIFF
--- a/inc/endpoints/class-components-endpoint.php
+++ b/inc/endpoints/class-components-endpoint.php
@@ -169,8 +169,6 @@ class Components_Endpoint extends Endpoint {
 		// Force trailing slashes on paths.
 		$this->force_trailing_slashes();
 
-		$this->data = load_template( $this->query, $this->data );
-
 		/**
 		 * Modify the output of the components route.
 		 *

--- a/inc/endpoints/class-components-endpoint.php
+++ b/inc/endpoints/class-components-endpoint.php
@@ -7,6 +7,8 @@
 
 namespace WP_Irving\REST_API;
 
+use WP_Irving\REST_API\Endpoint;
+
 /**
  * Components endpoint.
  */
@@ -166,6 +168,8 @@ class Components_Endpoint extends Endpoint {
 
 		// Force trailing slashes on paths.
 		$this->force_trailing_slashes();
+
+		$this->data = load_template( $this->query, $this->data );
 
 		/**
 		 * Modify the output of the components route.

--- a/inc/templates.php
+++ b/inc/templates.php
@@ -17,8 +17,8 @@ add_filter( 'wp_irving_components_route', __NAMESPACE__ . '\\load_template', 10,
  *
  * Based on wp-includes/template-loader.php.
  *
- * @param WP_Query $query   The current WP_Query object.
  * @param array    $data    Data object to be hydrated by templates.
+ * @param WP_Query $query   The current WP_Query object.
  * @param string   $context The context for this request.
  * @return array A hydrated data object.
  */

--- a/inc/templates.php
+++ b/inc/templates.php
@@ -20,7 +20,6 @@ add_filter( 'wp_irving_components_route', __NAMESPACE__ . '\\load_template', 10,
  * @param WP_Query $query   The current WP_Query object.
  * @param array    $data    Data object to be hydrated by templates.
  * @param string   $context The context for this request.
- *
  * @return array A hydrated data object.
  */
 function load_template( array $data, WP_Query $query, string $context ) : array {
@@ -105,7 +104,8 @@ function load_template( array $data, WP_Query $query, string $context ) : array 
  * which aren't filterable, so this implements a workaround to skip the file_exists checks
  * and return the template files for our own implementation of a locate_template function.
  *
- * @see    https://core.trac.wordpress.org/ticket/48175
+ * See: https://core.trac.wordpress.org/ticket/48175
+ *
  * @return void
  */
 function filter_template_loader() {
@@ -150,7 +150,7 @@ function filter_template_loader() {
  * @param array $templates A list of possible template files to load.
  * @return string The path to the found template.
  */
-function locate_template( $templates ) {
+function locate_template( array $templates ) : string {
 	$template_path = STYLESHEETPATH . '/templates/';
 
 	/**

--- a/inc/templates.php
+++ b/inc/templates.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Templates.
+ *
+ * @package WP_Irving
+ */
+
+namespace WP_Irving;
+
+use WP_Query;
+
+/**
+ * Shallow template loader using core's template hierarchy.
+ *
+ * Based on wp-includes/template-loader.php.
+ *
+ * @param WP_Query $query The current WP_Query object.
+ * @param array    $data  Current array containing component response data.
+ * @return string The loaded template based on the template hierarchy.
+ */
+function load_template( WP_Query $query, $data ) {
+	// Filter the template hierarchy before processing.
+	filter_template_loader();
+
+    $tag_templates = array(
+		'is_embed'             => 'get_embed_template',
+		'is_404'               => 'get_404_template',
+		'is_search'            => 'get_search_template',
+		'is_front_page'        => 'get_front_page_template',
+		'is_home'              => 'get_home_template',
+		'is_privacy_policy'    => 'get_privacy_policy_template',
+		'is_post_type_archive' => 'get_post_type_archive_template',
+		'is_tax'               => 'get_taxonomy_template',
+		'is_attachment'        => 'get_attachment_template',
+		'is_single'            => 'get_single_template',
+		'is_page'              => 'get_page_template',
+		'is_singular'          => 'get_singular_template',
+		'is_category'          => 'get_category_template',
+		'is_tag'               => 'get_tag_template',
+		'is_author'            => 'get_author_template',
+		'is_date'              => 'get_date_template',
+		'is_archive'           => 'get_archive_template',
+	);
+
+    $template = false;
+
+	// Loop through each of the template conditionals, and find the appropriate template file.
+	foreach ( $tag_templates as $tag => $template_getter ) {
+		if ( call_user_func( [ $query, $tag ] ) ) {
+			$template = call_user_func( $template_getter );
+		}
+
+        // Unsure if this is needed in JSON context.
+		if ( $template ) {
+			if ( 'is_attachment' === $tag ) {
+				remove_filter( 'the_content', 'prepend_attachment' );
+			}
+
+			break;
+		}
+	}
+
+	if ( ! $template ) {
+		$template = get_index_template();
+    }
+
+	/**
+	 * Filters the path of the current template before including it.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param string $template The path of the template to include.
+	 */
+    $template = apply_filters( 'wp_irving_template_include', $template, $query );
+
+    if ( $template ) {
+        ob_start();
+        include $template;
+        $data['page'] = ob_get_clean();
+    }
+
+    return $data;
+}
+
+/**
+ * Filter the WordPress template locating algorithm.
+ *
+ * The locate_template function in WordPress checks for hard coded template paths
+ * which aren't filterable, so this implements a workaround to skip the file_exists checks
+ * and return the template files for our own implementation of a locate_template function.
+ *
+ * @see    https://core.trac.wordpress.org/ticket/48175
+ * @return void
+ */
+function filter_template_loader() {
+	// All supported template types in WP Core.
+	$template_types = [
+        'index',
+        '404',
+        'archive',
+        'author',
+        'category',
+        'tag',
+        'taxonomy',
+        'date',
+        'embed',
+        'home',
+        'frontpage',
+        'privacypolicy',
+        'page',
+        'paged',
+        'search',
+        'single',
+        'singular',
+        'attachment',
+	];
+
+	// Return an empty array in {$type}_template_hierarchy to avoid file lookups but use
+	// the located templates to filter {$type}_template with our custom location.
+	foreach ( $template_types as $type ) {
+        add_filter( "{$type}_template_hierarchy", function ( $templates ) use ( $type ) {
+            add_filter( "{$type}_template", function () use ( $templates ) {
+                return locate_template( $templates );
+            } );
+
+            return [];
+        } );
+	}
+}
+
+/**
+ * Return a located template file.
+ *
+ * @param array $templates A list of possible template files to load.
+ * @return string The path to the found template.
+ */
+function locate_template( $templates ) {
+    $template_path = STYLESHEETPATH . '/templates/';
+
+    /**
+     * Filter the path to Irving templates.
+     *
+     * @param string $template_path The full path to the template folder.
+     * @param array  $templates     A list of template files to locate.
+     */
+    apply_filters( 'wp_irving_template_path', $template_path, $templates );
+
+    $located = '';
+
+    foreach ( $templates as $template ) {
+        if ( file_exists( $template_path . $template ) ) {
+			$located = $template_path . $template;
+			break;
+		}
+    }
+
+    return $located;
+}

--- a/wp-irving.php
+++ b/wp-irving.php
@@ -47,5 +47,8 @@ require_once WP_IRVING_PATH . '/inc/redirects.php';
 // Rewrite rules.
 require_once WP_IRVING_PATH . '/inc/rewrites.php';
 
+// Template loading.
+require_once WP_IRVING_PATH . '/inc/templates.php';
+
 // Debugging helpers.
 require_once WP_IRVING_PATH . '/inc/debug.php';


### PR DESCRIPTION
This adds the ability to automatically load templates in a theme based on the default WordPress template hierarchy.

By default, this will look in the active theme for a `templates` directory and will load either a `php`, `json`, or `html` file (in that order) based on the current `WP_Query` object. 

For example, if the path is to a generic archive page, this will try to load `/templates/archive.php`, `/templates/archive.json`, `/templates/index.php`, `/templates/index.json`, etc. The path to the template location is filterable using the new `wp_irving_template_path` hook.

If the context is `site`, this will also attempt to load a `defaults.php` or `defaults.json` template.

To test this, add a templates directory to your active theme and add [the example files from this gist](https://gist.github.com/joemcgill/558cd5af0b7c2edc174bc1d5ef9df783).

Hitting the Irving endpoint with a path for a specific post or page should return the `single.json` data, while hitting any other path should show the `index.json` data. Include `context=site` in your REST request to see the response hydrated with data from the defaults.json.