### PR TITLE
Add functionality to cache class, add Pantheon integration

### DIFF
--- a/inc/class-cache.php
+++ b/inc/class-cache.php
@@ -104,7 +104,7 @@ class Cache {
 			return;
 		}
 
-		// Fire the request to WordPress VIP.
+		// Fire the request to bust both VIP and Irving Redis cache.
 		wp_remote_request( $permalink, [ 'method' => 'PURGE' ] );
 	}
 

--- a/inc/class-cache.php
+++ b/inc/class-cache.php
@@ -176,7 +176,6 @@ class Cache {
 	 *
 	 * @param int|\WP_Post $post_id A WP Post object or a post ID.
 	 * @return array Purge URLs
-	 * @todo do we even need feed URLs for Irving?
 	 */
 	public function get_post_purge_urls( $post_id ) : array {
 		$post_purge_urls = [];
@@ -227,20 +226,14 @@ class Cache {
 
 		// Purge author urls.
 		$post_author_id  = get_post_field( 'post_author', $current_post );
-		$user_purge_urls = $this->get_user_purge_urls( $post_author_id );
+		$post_purge_urls = array_merge( $post_purge_urls, $this->get_user_purge_urls( $post_author_id ) );
 
-		// Purge the standard site feeds.
-		$site_feeds = [
-			get_bloginfo( 'rdf_url' ),
-			get_bloginfo( 'rss_url' ),
-			get_bloginfo( 'rss2_url' ),
-			get_bloginfo( 'atom_url' ),
-			get_bloginfo( 'comments_atom_url' ),
-			get_bloginfo( 'comments_rss2_url' ),
-			get_post_comments_feed_link( $current_post->ID ),
-		];
-
-		return array_merge( $post_purge_urls, $user_purge_urls, $site_feeds );
+		/**
+		 * Filter array of URLs to purge when a post action is triggered.
+		 *
+		 * @param array $post_purge_urls List of URLs to purge for this post.
+		 */
+		return apply_filters( 'wp_irving_cache_post_purge_urls', $post_purge_urls );
 	}
 
 	/**
@@ -248,8 +241,6 @@ class Cache {
 	 *
 	 * @param int|\WP_Term $term A WP Term object, or a term ID.
 	 * @return array Purge URLs
-	 * @todo determine if this separate function is even necessary.
-	 * @todo determine if we should also purge posts with this term assigned.
 	 */
 	public function get_term_purge_urls( $term ) : array {
 		$term_purge_urls = [];
@@ -289,7 +280,12 @@ class Cache {
 			$term_purge_urls = array_merge( $term_purge_urls, $this->get_single_term_purge_urls( $term ) );
 		}
 
-		return array_unique( $term_purge_urls );
+		/**
+		 * Filter array of URLs to purge when a term action is triggered.
+		 *
+		 * @param array $term_purge_urls List of URLs to purge for this term.
+		 */
+		return apply_filters( 'wp_irving_cache_term_purge_urls', array_unique( $term_purge_urls ) );
 	}
 
 	/**
@@ -297,7 +293,6 @@ class Cache {
 	 *
 	 * @param  WP_Term $term A WP term object.
 	 * @return array An array of URLs to be purged
-	 * @todo maybe purge pagination URLs.
 	 */
 	public function get_single_term_purge_urls( $term ) : array {
 		$term_purge_urls = [];
@@ -325,8 +320,6 @@ class Cache {
 	 *
 	 * @param int|\WP_User $user User object or ID.
 	 * @return array An array of URLs to be purged.
-	 * @todo maybe purge pagination URLs.
-	 * @todo determine if we should also purge posts authored by this user.
 	 */
 	public function get_user_purge_urls( $user ) : array {
 		$user_purge_urls = [];
@@ -354,7 +347,12 @@ class Cache {
 			$user_purge_urls[] = $maybe_purge_feed_url;
 		}
 
-		return $user_purge_urls;
+		/**
+		 * Filter array of URLs to purge when a user action is triggered.
+		 *
+		 * @param array $user_purge_urls List of URLs to purge for this user.
+		 */
+		return apply_filters( 'wp_irving_cache_user_purge_urls', $user_purge_urls );
 	}
 
 	/**

--- a/inc/class-cache.php
+++ b/inc/class-cache.php
@@ -369,8 +369,6 @@ class Cache {
 
 	/**
 	 * Fire purge request.
-	 *
-	 * @param string $permalink Permalink.
 	 */
 	public function fire_purge_request() {
 		// Do not fire purges while importing.
@@ -382,7 +380,7 @@ class Cache {
 		}
 
 		// Fire the request to bust both VIP and Irving Redis cache.
-		$response = wp_remote_post(
+		wp_remote_post(
 			home_url( '/purge-cache' ),
 			[
 				'body'    => json_encode( [ 'paths' => self::$purge_queue ] ),
@@ -398,7 +396,7 @@ class Cache {
 	 * Fire wipe out request.
 	 */
 	public function fire_wipe_request() {
-		$response = wp_remote_post( home_url( '/purge-cache' ) );
+		wp_remote_post( home_url( '/purge-cache' ) );
 	}
 
 	/**

--- a/inc/class-cache.php
+++ b/inc/class-cache.php
@@ -357,7 +357,14 @@ class Cache {
 	 * @param array $permalinks Permalinks.
 	 */
 	public function queue_bulk_purge_request( $permalinks = [] ) {
-		self::$purge_queue = array_unique( array_merge( self::$purge_queue, $permalinks ) );
+		self::$purge_queue = array_unique(
+			array_map(
+				function ( $url ) {
+					return str_replace( home_url(), '', $url );
+				},
+				array_merge( self::$purge_queue, $permalinks )
+			)
+		);
 	}
 
 	/**
@@ -378,7 +385,7 @@ class Cache {
 		$response = wp_remote_post(
 			home_url( '/purge-cache' ),
 			[
-				'body'    => json_encode( [ 'urls' => self::$purge_queue ] ),
+				'body'    => json_encode( [ 'paths' => self::$purge_queue ] ),
 				'headers' => [
 					'Content-Type' => 'application/json; charset=utf-8',
 				],

--- a/inc/class-cache.php
+++ b/inc/class-cache.php
@@ -39,14 +39,359 @@ class Cache {
 		// Register admin page.
 		add_action( 'admin_menu', [ $this, 'register_admin' ] );
 
-		// Purging actions.
+		// Post purging actions.
 		add_action( 'wp_insert_post', [ $this, 'on_update_post' ], 10, 2 );
 		add_action( 'clean_post_cache', [ $this, 'on_clean_post_cache' ], 10, 2 );
 		add_action( 'transition_post_status', [ $this, 'on_post_status_transition' ], 10, 3 );
 		add_action( 'before_delete_post', [ $this, 'on_before_delete_post' ] );
 		add_action( 'delete_attachment', [ $this, 'on_delete_attachment' ] );
 
+		// Term purging actions.
+		add_action( 'created_term', [ $this, 'on_created_term' ], 10, 3 );
+		add_action( 'edited_term', [ $this, 'on_edited_term' ] );
+		add_action( 'delete_term', [ $this, 'on_delete_term' ] );
+		add_action( 'clean_term_cache', [ $this, 'on_clean_term_cache' ] );
+
+		// User purging actions.
+		add_action( 'clean_user_cache', [ $this, 'on_clean_user_cache' ] );
+
 		add_action( 'init', [ $this, 'purge_cache_request' ] );
+	}
+
+	/**
+	 * Purge cache on post update.
+	 *
+	 * @param int     $post_id Post ID.
+	 * @param WP_Post $post    Post object.
+	 */
+	public function on_update_post( $post_id, $post ) {
+		if ( 'publish' !== $post->post_status ) {
+			return;
+		}
+
+		// Purge cache.
+		$this->fire_post_purge_requests( $post_id );
+	}
+
+	/**
+	 * Purge cache on post cache clear.
+	 *
+	 * @param int     $post_id Post ID.
+	 * @param WP_Post $post    Post object.
+	 */
+	public function on_clean_post_cache( $post_id, $post ) {
+		if ( 'publish' !== $post->post_status ) {
+			return;
+		}
+
+		// Purge cache.
+		$this->fire_post_purge_requests( $post_id );
+	}
+
+	/**
+	 * Purge cache on page transition.
+	 *
+	 * @param string  $new_status New Status.
+	 * @param string  $old_status Old Status.
+	 * @param WP_Post $post       Post object.
+	 */
+	public function on_post_status_transition( $new_status, $old_status, $post ) {
+		if ( 'publish' !== $new_status && 'publish' !== $old_status ) {
+			return;
+		}
+
+		// Purge cache.
+		$this->fire_post_purge_requests( $post );
+	}
+
+	/**
+	 * Purge on post delete.
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	public function on_before_delete_post( $post_id ) {
+		$this->fire_post_purge_requests( $post_id );
+	}
+
+	/**
+	 * Purge attachment on delete.
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	public function on_delete_attachment( $post_id ) {
+		$this->fire_post_purge_requests( $post_id );
+	}
+
+	/**
+	 * Purge term cache on create.
+	 *
+	 * @param int\WP_Term $term_id Term ID.
+	 */
+	public function on_created_term( $term_id ) {
+		$this->fire_term_purge_requests( $term_id );
+	}
+
+	/**
+	 * Purge term cache on edit.
+	 *
+	 * @param int\WP_Term $term_id Term ID.
+	 */
+	public function on_edited_term( $term_id ) {
+		$this->fire_term_purge_requests( $term_id );
+	}
+
+	/**
+	 * Purge term cache on delete.
+	 *
+	 * @param int\WP_Term $term_id Term ID.
+	 */
+	public function on_deleted_term( $term_id ) {
+		$this->fire_term_purge_requests( $term_id );
+	}
+
+	/**
+	 * Purge terms on clean cache.
+	 *
+	 * @param array $term_ids Term IDs.
+	 */
+	public function on_clean_term_cache( $term_ids ) {
+		$ids = is_array( $term_ids ) ? $term_ids : array( $term_ids );
+
+		foreach ( $ids as $term_id ) {
+			$this->fire_term_purge_requests( $term_id );
+		}
+	}
+
+	/**
+	 * Purge user on clean cache.
+	 *
+	 * @param array $user_id User ID.
+	 */
+	public function on_clean_user_cache( $user_id ) {
+		$this->fire_user_purge_requests( $user_id );
+	}
+
+	/**
+	 * Get an array of URLS to purge for a post.
+	 *
+	 * @param int|\WP_Post $post_id A WP Post object or a post ID.
+	 * @return array Purge URLs
+	 */
+	public function get_post_purge_urls( $post_id ) : array {
+		$post_purge_urls = [];
+
+		if ( defined( 'WP_IMPORTING' ) && true === WP_IMPORTING ) {
+			return $post_purge_urls;
+		}
+
+		$current_post = get_post( $post_id );
+
+		if (
+			empty( $current_post )
+			|| 'revision' === $current_post->post_type
+			|| ! in_array( get_post_status( $post_id ), array( 'publish', 'inherit', 'trash' ), true )
+			|| ! is_post_type_viewable( $current_post->post_type )
+			// Skip purge if it is a new attachment.
+			|| ( 'attachment' === $current_post->post_type && $current_post->post_date === $current_post->post_modified )
+		) {
+			return $post_purge_urls;
+		}
+
+		$post_purge_urls[] = get_permalink( $post_id );
+		$post_purge_urls[] = home_url( '/' );
+
+		// Don't just purge the attachment page, but also include the file itself.
+		if ( 'attachment' === $current_post->post_type ) {
+			$post_purge_urls[] = wp_get_attachment_url( $post_id );
+		}
+
+		$taxonomies = get_object_taxonomies( $current_post, 'object' );
+
+		foreach ( $taxonomies as $taxonomy ) {
+			if ( true !== $taxonomy->public ) {
+				continue;
+			}
+
+			$taxonomy_name = $taxonomy->name;
+			$terms         = get_the_terms( $post_id, $taxonomy_name );
+
+			if ( false === $terms ) {
+				continue;
+			}
+
+			foreach ( $terms as $term ) {
+				$post_purge_urls = array_merge( $post_purge_urls, $this->get_single_term_purge_urls( $term ) );
+			}
+		}
+
+		// Purge author urls.
+		$post_author_id  = get_post_field( 'post_author', $post_id );
+		$user_purge_urls = $this->get_user_purge_urls( $post_author_id );
+
+		// Purge the standard site feeds.
+		// @TODO Do we need to PURGE the comment feeds if the post_status is publish?
+		$site_feeds = [
+			get_bloginfo( 'rdf_url' ),
+			get_bloginfo( 'rss_url' ),
+			get_bloginfo( 'rss2_url' ),
+			get_bloginfo( 'atom_url' ),
+			get_bloginfo( 'comments_atom_url' ),
+			get_bloginfo( 'comments_rss2_url' ),
+			get_post_comments_feed_link( $post_id ),
+		];
+
+		return array_merge( $post_purge_urls, $user_purge_urls, $site_feeds );
+	}
+
+	/**
+	 * Get an array of URLS to purge for terms. This will handle hierarchical terms as well.
+	 *
+	 * @param int|\WP_Term $term A WP Term object, or a term ID.
+	 * @return array Purge URLs
+	 */
+	public function get_term_purge_urls( $term ) : array {
+		$term_purge_urls = [];
+		$term = get_term( $term );
+
+		if ( is_wp_error( $term ) || empty( $term ) ) {
+			return $term_purge_urls;
+		}
+
+		// Before adding term to purge URLs, make sure we actually need to do it.
+		$term_ids        = [ $term->term_id ];
+		$taxonomy_object = get_taxonomy( $term->taxonomy );
+
+		if (
+			! $taxonomy_object
+			|| (
+				false === $taxonomy_object->public
+				&& false === $taxonomy_object->publicly_queryable
+				&& false === $taxonomy_object->show_in_rest
+			)
+		) {
+			return $term_purge_urls;
+		}
+
+		$get_term_args = array(
+			'taxonomy'    => $term->taxonomy,
+			'include'     => $term_ids,
+			'hide_empty'  => false,
+		);
+		$terms = get_terms( $get_term_args );
+
+		if ( is_wp_error( $terms ) ) {
+			return $term_purge_urls;
+		}
+
+		foreach ( $terms as $term ) {
+			$term_purge_urls = array_merge( $term_purge_urls, $this->get_single_term_purge_urls( $term ) );
+		}
+
+		return array_unique( $term_purge_urls );
+	}
+
+	/**
+	 * Get all URLs to be purged for a given term.
+	 *
+	 * @param  WP_Term $term A WP term object.
+	 * @return array An array of URLs to be purged
+	 * @todo maybe purge pagination URLs.
+	 */
+	public function get_single_term_purge_urls( $term ) : array {
+		$term_purge_urls = [];
+
+		// Purge term archive.
+		$taxonomy_name   = $term->taxonomy;
+		$maybe_purge_url = get_term_link( $term, $taxonomy_name );
+
+		if ( ! empty( $maybe_purge_url ) && ! is_wp_error( $maybe_purge_url ) && is_string( $maybe_purge_url ) ) {
+			$term_purge_urls[] = $maybe_purge_url;
+		}
+
+		// Purge term feed.
+		$maybe_purge_feed_url = get_term_feed_link( intval( $term->term_id ), $taxonomy_name );
+
+		if ( false !== $maybe_purge_feed_url ) {
+			$term_purge_urls[] = $maybe_purge_feed_url;
+		}
+
+		return $term_purge_urls;
+	}
+
+	/**
+	 * Get all URLs to be purged for a given term
+	 *
+	 * @param int|\WP_User $user User object or ID.
+	 * @return array An array of URLs to be purged.
+	 * @todo maybe purge pagination URLs.
+	 */
+	public function get_user_purge_urls( $user ) : array {
+		$user_purge_urls = [];
+
+		if (
+			empty( $user ) ||
+			( ! $user instanceof \WP_User && ! is_numeric( $user ) )
+		) {
+			return $user_purge_urls;
+		}
+
+		// Purge user archive.
+		$user_id         = ( $user instanceof \WP_User ) ? $user->ID : $user;
+		$maybe_purge_url = get_author_posts_url( $user_id );
+
+		if ( ! empty( $maybe_purge_url ) && ! is_wp_error( $maybe_purge_url ) && is_string( $maybe_purge_url ) ) {
+			$user_purge_urls[] = $maybe_purge_url;
+		}
+
+		// Purge user feeds.
+		$maybe_purge_feed_url = get_author_feed_link( $user_id );
+
+		if ( false !== $maybe_purge_feed_url ) {
+			$user_purge_urls[] = $maybe_purge_feed_url;
+		}
+
+		return $user_purge_urls;
+	}
+
+	/**
+	 * Fire purge requests for post purge urls.
+	 *
+	 * @param int\WP_Post $post Post object or ID.
+	 */
+	public function fire_post_purge_requests( $post ) {
+		$purge_urls = $this->get_post_purge_urls( $post );
+		$this->fire_bulk_purge_request( $purge_urls );
+	}
+
+	/**
+	 * Fire purge requests for term purge urls.
+	 *
+	 * @param int\WP_Term $term Term object or ID.
+	 */
+	public function fire_term_purge_requests( $term ) {
+		$purge_urls = $this->get_term_purge_urls( $term );
+		$this->fire_bulk_purge_request( $purge_urls );
+	}
+
+	/**
+	 * Fire purge requests for user purge urls.
+	 *
+	 * @param int\WP_User $user user object or ID.
+	 */
+	public function fire_user_purge_requests( $user ) {
+		$purge_urls = $this->get_user_purge_urls( $user );
+		$this->fire_bulk_purge_request( $purge_urls );
+	}
+
+	/**
+	 * Fire purge requests for an array of permalinks.
+	 *
+	 * @param array $permalinks Permalinks.
+	 */
+	public function fire_bulk_purge_request( $permalinks = [] ) {
+		foreach ( $permalinks as $permalink ) {
+			$this->fire_purge_request( $permalink );
+		}
 	}
 
 	/**
@@ -77,70 +422,6 @@ class Cache {
 	}
 
 	/**
-	 * Clear cache on post update.
-	 *
-	 * @param int     $post_id Post ID.
-	 * @param WP_Post $post    Post object.
-	 */
-	public function on_update_post( $post_id, $post ) {
-		if ( 'publish' !== $post->post_status ) {
-			return;
-		}
-
-		// Purge cache.
-		$this->fire_purge_request( get_the_permalink( $post_id ) );
-	}
-
-	/**
-	 * Clear cache on post cache clear.
-	 *
-	 * @param int     $post_id Post ID.
-	 * @param WP_Post $post    Post object.
-	 */
-	public function on_clean_post_cache( $post_id, $post ) {
-		if ( 'publish' !== $post->post_status ) {
-			return;
-		}
-
-		// Purge cache.
-		$this->fire_purge_request( get_the_permalink( $post_id ) );
-	}
-
-	/**
-	 * Clear cache on page transition.
-	 *
-	 * @param string  $new_status New Status.
-	 * @param string  $old_status Old Status.
-	 * @param WP_Post $post       Post object.
-	 */
-	public function on_post_status_transition( $new_status, $old_status, $post ) {
-		if ( 'publish' !== $new_status && 'publish' !== $old_status ) {
-			return;
-		}
-
-		// Purge cache.
-		$this->fire_purge_request( get_the_permalink( $post->ID ) );
-	}
-
-	/**
-	 * Clear on post delete.
-	 *
-	 * @param int $post_id Post ID.
-	 */
-	public function on_before_delete_post( $post_id ) {
-		$this->fire_purge_request( get_the_permalink( $post_id ) );
-	}
-
-	/**
-	 * Clear attachment on delete.
-	 *
-	 * @param int $post_id Post ID.
-	 */
-	public function on_delete_attachment( $post_id ) {
-		$this->fire_purge_request( get_the_permalink( $post_id ) );
-	}
-
-	/**
 	 * Purge cache on a PURGE request.
 	 */
 	public function purge_cache_request() {
@@ -155,188 +436,6 @@ class Cache {
 		}
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
 		// phpcs:enable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-	}
-
-	/**
-	 * Get an array of URLS to purge for a post.
-	 *
-	 * @param object|int $term A WP Post object, or a post ID
-	 * @return array Purge URLs
-	 */
-	public function get_post_purge_urls( $post_id ) {
-		$post_purge_urls = [];
-
-		if ( defined( 'WP_IMPORTING' ) && true === WP_IMPORTING ) {
-			return false;
-		}
-
-		$post = get_post( $post_id );
-
-		if (
-			empty( $post )
-		    || 'revision' === $post->post_type
-			|| ! in_array( get_post_status( $post_id ), array( 'publish', 'inherit', 'trash' ), true )
-			|| ! is_post_type_viewable( $post->post_type )
-			// Skip purge if it is a new attachment
-			|| ( 'attachment' === $post->post_type && $post->post_date === $post->post_modified )
-		) {
-			return false;
-		}
-
-		$post_purge_urls[] = get_permalink( $post_id );
-		$post_purge_urls[] = home_url( '/' );
-
-		// Don't just purge the attachment page, but also include the file itself
-		if ( 'attachment' === $post->post_type ) {
-			$post_purge_urls[] = wp_get_attachment_url( $post_id );
-		}
-
-		$taxonomies = get_object_taxonomies( $post, 'object' );
-
-		foreach ( $taxonomies as $taxonomy ) {
-			if ( true !== $taxonomy->public ) {
-				continue;
-			}
-
-			$taxonomy_name = $taxonomy->name;
-			$terms         = get_the_terms( $post_id, $taxonomy_name );
-
-			if ( false === $terms ) {
-				continue;
-			}
-
-			foreach ( $terms as $term ) {
-				$post_purge_urls = array_merge( $post_purge_urls, $this->get_purge_urls_for_term( $term ) );
-			}
-		}
-
-		// Purge author urls.
-		$post_author_id  = get_post_field( 'post_author', $post_id );
-		$user_purge_urls = $this->get_user_purge_urls( $post_author_id );
-
-		// Purge the standard site feeds
-		// @TODO Do we need to PURGE the comment feeds if the post_status is publish?
-		$site_feeds = [
-			get_bloginfo( 'rdf_url' ),
-			get_bloginfo( 'rss_url')  ,
-			get_bloginfo( 'rss2_url' ),
-			get_bloginfo( 'atom_url' ),
-			get_bloginfo( 'comments_atom_url' ),
-			get_bloginfo( 'comments_rss2_url' ),
-			get_post_comments_feed_link( $post_id ),
-		];
-
-		return array_merge( $post_purge_urls, $user_purge_urls, $site_feeds );
-	}
-
-	/**
-	 * Get an array of URLS to purge for terms.
-	 *
-	 * @param object|int $term A WP Term object, or a term ID
-	 * @return array Purge URLs
-	 */
-	public function get_term_purge_urls( $term ) {
-		$term_purge_urls = [];
-		$term = get_term( $term );
-
-		if ( is_wp_error( $term ) || empty( $term ) ) {
-			return $term_purge_urls;
-		}
-
-		// Before adding term to purge URLs, make sure we actually need to do it.
-		$term_ids        = array( $term->term_id );
-		$taxonomy_object = get_taxonomy( $term->taxonomy );
-
-		if (
-			! $taxonomy_object
-			|| (
-				false === $taxonomy_object->public
-				&& false === $taxonomy_object->publicly_queryable
-				&& false === $taxonomy_object->show_in_rest
-			)
-		) {
-			return $term_purge_urls;
-		}
-
-		$get_term_args = array(
-			'taxonomy'    => $term->taxonomy,
-			'include'     => $term_ids,
-			'hide_empty'  => false,
-		);
-		$terms = get_terms( $get_term_args );
-
-		if ( is_wp_error( $terms ) ) {
-			return $term_purge_urls;
-		}
-
-		foreach ( $terms as $term ) {
-			$term_purge_urls = array_merge( $term_purge_urls, $this->get_purge_urls_for_term( $term ) );
-		}
-
-		return array_unique( $term_purge_urls );
-	}
-
-	/**
-	 * Get all URLs to be purged for a given term
-	 *
-	 * @param object $term A WP term object
-	 * @return array An array of URLs to be purged
-	 * @todo maybe purge pagination URLs.
-	 */
-	public function get_purge_urls_for_term( $term ) {
-		$term_purge_urls = [];
-
-		// Purge term archive.
-		$taxonomy_name   = $term->taxonomy;
-		$maybe_purge_url = get_term_link( $term, $taxonomy_name );
-
-		if ( ! empty( $maybe_purge_url ) && ! is_wp_error( $maybe_purge_url ) && is_string( $maybe_purge_url ) ) {
-			$term_purge_urls[] = $maybe_purge_url;
-		}
-
-		// Purge term feed.
-		$maybe_purge_feed_url = get_term_feed_link( intval( $term->term_id ), $taxonomy_name );
-
-		if ( false !== $maybe_purge_feed_url ) {
-			$term_purge_urls[] = $maybe_purge_feed_url;
-		}
-
-		return $term_purge_urls;
-	}
-
-	/**
-	 * Get all URLs to be purged for a given term
-	 *
-	 * @param object $user_id User object or ID
-	 * @return array An array of URLs to be purged
-	 * @todo maybe purge pagination URLs.
-	 */
-	public function get_user_purge_urls( $user ) {
-		$user_purge_urls = [];
-
-		if (
-			empty ( $user ) ||
-			( ! $user instanceof \WP_User && ! is_numeric( $user ) )
-		) {
-			return $user_purge_urls;
-		}
-
-		// Purge user archive.
-		$user_id         = ( $user instanceof \WP_User ) ? $user->ID : $user;
-		$maybe_purge_url = get_author_posts_url( $user_id );
-
-		if ( ! empty( $maybe_purge_url ) && ! is_wp_error( $maybe_purge_url ) && is_string( $maybe_purge_url ) ) {
-			$user_purge_urls[] = $maybe_purge_url;
-		}
-
-		// Purge user feeds.
-		$maybe_purge_feed_url = get_author_feed_link( $user_id );
-
-		if ( false !== $maybe_purge_feed_url ) {
-			$user_purge_urls[] = $maybe_purge_feed_url;
-		}
-
-		return $user_purge_urls;
 	}
 
 	/**
@@ -387,14 +486,14 @@ class Cache {
 				<?php settings_fields( 'irving-cache' ); ?>
 
 				<h2>
-					<?php esc_html_e( 'Clear Site Cache', 'wp-irving' ); ?>
+					<?php esc_html_e( 'Purge Site Cache', 'wp-irving' ); ?>
 				</h2>
 
 				<p>
-					<?php esc_html_e( 'Use with care. Clearing the entire site cache will negatively impact performance for a short period of time.', 'wp-irving' ); ?>
+					<?php esc_html_e( 'Use with care. Purgeing the entire site cache will negatively impact performance for a short period of time.', 'wp-irving' ); ?>
 				</p>
 
-				<?php submit_button( __( 'Clear Cache', 'wp-irving' ) ); ?>
+				<?php submit_button( __( 'Purge Cache', 'wp-irving' ) ); ?>
 			</form>
 
 			<hr>
@@ -406,6 +505,6 @@ class Cache {
 add_action(
 	'init',
 	function() {
-		( new \WP_Irving\Cache )->instance();
+		\WP_Irving\Cache::instance();
 	}
 );

--- a/inc/class-cache.php
+++ b/inc/class-cache.php
@@ -176,6 +176,7 @@ class Cache {
 	 *
 	 * @param int|\WP_Post $post_id A WP Post object or a post ID.
 	 * @return array Purge URLs
+	 * @todo do we even need feed URLs for Irving?
 	 */
 	public function get_post_purge_urls( $post_id ) : array {
 		$post_purge_urls = [];
@@ -229,7 +230,6 @@ class Cache {
 		$user_purge_urls = $this->get_user_purge_urls( $post_author_id );
 
 		// Purge the standard site feeds.
-		// @TODO Do we need to PURGE the comment feeds if the post_status is publish?
 		$site_feeds = [
 			get_bloginfo( 'rdf_url' ),
 			get_bloginfo( 'rss_url' ),
@@ -248,12 +248,14 @@ class Cache {
 	 *
 	 * @param int|\WP_Term $term A WP Term object, or a term ID.
 	 * @return array Purge URLs
+	 * @todo determine if this separate function is even necessary.
+	 * @todo determine if we should also purge posts with this term assigned.
 	 */
 	public function get_term_purge_urls( $term ) : array {
 		$term_purge_urls = [];
 		$term = get_term( $term );
 
-		if ( is_wp_error( $term ) || empty( $term ) ) {
+		if ( is_wp_error( $term ) || empty( $term ) || ( defined( 'WP_IMPORTING' ) && true === WP_IMPORTING ) ) {
 			return $term_purge_urls;
 		}
 
@@ -291,7 +293,7 @@ class Cache {
 	}
 
 	/**
-	 * Get all URLs to be purged for a given term.
+	 * Get all URLs to be purged for a single term.
 	 *
 	 * @param  WP_Term $term A WP term object.
 	 * @return array An array of URLs to be purged
@@ -324,13 +326,15 @@ class Cache {
 	 * @param int|\WP_User $user User object or ID.
 	 * @return array An array of URLs to be purged.
 	 * @todo maybe purge pagination URLs.
+	 * @todo determine if we should also purge posts authored by this user.
 	 */
 	public function get_user_purge_urls( $user ) : array {
 		$user_purge_urls = [];
 
 		if (
-			empty( $user ) ||
-			( ! $user instanceof \WP_User && ! is_numeric( $user ) )
+			empty( $user )
+			|| ( ! $user instanceof \WP_User && ! is_numeric( $user ) )
+			|| ( defined( 'WP_IMPORTING' ) && true === WP_IMPORTING )
 		) {
 			return $user_purge_urls;
 		}
@@ -490,7 +494,7 @@ class Cache {
 				</h2>
 
 				<p>
-					<?php esc_html_e( 'Use with care. Purgeing the entire site cache will negatively impact performance for a short period of time.', 'wp-irving' ); ?>
+					<?php esc_html_e( 'Use with care. Purging the entire site cache will negatively impact performance for a short period of time.', 'wp-irving' ); ?>
 				</p>
 
 				<?php submit_button( __( 'Purge Cache', 'wp-irving' ) ); ?>

--- a/inc/class-cache.php
+++ b/inc/class-cache.php
@@ -392,13 +392,6 @@ class Cache {
 			]
 		);
 		self::$purge_queue = [];
-
-		// Temp debugging.
-		if ( $response instanceof \WP_Error ) {
-			update_option( 'debug_purge_response', $response->get_error_message() );
-		} else {
-			update_option( 'debug_purge_response', $response['body'] ?? '' );
-		}
 	}
 
 	/**
@@ -406,13 +399,6 @@ class Cache {
 	 */
 	public function fire_wipe_request() {
 		$response = wp_remote_post( home_url( '/purge-cache' ) );
-
-		// Temp debugging.
-		if ( $response instanceof \WP_Error ) {
-			update_option( 'debug_wipe_response', $response->get_error_message() );
-		} else {
-			update_option( 'debug_wipe_response', $response['body'] ?? '' );
-		}
 	}
 
 	/**

--- a/inc/class-cache.php
+++ b/inc/class-cache.php
@@ -50,6 +50,33 @@ class Cache {
 	}
 
 	/**
+	 * Fire purge request.
+	 *
+	 * @param string $permalink Permalink.
+	 */
+	public function fire_purge_request( $permalink = '' ) {
+		// Do not fire purges while importing.
+		if ( defined( 'WP_IMPORTING' ) && WP_IMPORTING ) {
+			return;
+		}
+
+		// Bail early.
+		if ( empty( $permalink ) ) {
+			return;
+		}
+
+		// Fire the request to bust both VIP and Irving Redis cache.
+		wp_remote_request( $permalink, [ 'method' => 'PURGE' ] );
+	}
+
+	/**
+	 * Fire wipe out request.
+	 */
+	public function fire_wipe_request() {
+		wp_remote_get( home_url( '/purge-cache' ) );
+	}
+
+	/**
 	 * Clear cache on post update.
 	 *
 	 * @param int     $post_id Post ID.
@@ -114,26 +141,6 @@ class Cache {
 	}
 
 	/**
-	 * Fire purge request.
-	 *
-	 * @param string $permalink Permalink.
-	 */
-	protected function fire_purge_request( $permalink = '' ) {
-		// Do not fire purges while importing.
-		if ( defined( 'WP_IMPORTING' ) && WP_IMPORTING ) {
-			return;
-		}
-
-		// Bail early.
-		if ( empty( $permalink ) ) {
-			return;
-		}
-
-		// Fire the request to bust both VIP and Irving Redis cache.
-		wp_remote_request( $permalink, [ 'method' => 'PURGE' ] );
-	}
-
-	/**
 	 * Purge cache on a PURGE request.
 	 */
 	public function purge_cache_request() {
@@ -148,13 +155,6 @@ class Cache {
 		}
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
 		// phpcs:enable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-	}
-
-	/**
-	 * Fire wipe out request.
-	 */
-	protected function fire_wipe_request() {
-		wp_remote_get( home_url( '/purge-cache' ) );
 	}
 
 	/**

--- a/inc/class-cache.php
+++ b/inc/class-cache.php
@@ -190,7 +190,7 @@ class Cache {
 		if (
 			empty( $current_post )
 			|| 'revision' === $current_post->post_type
-			|| ! in_array( get_post_status( $post_id ), array( 'publish', 'inherit', 'trash' ), true )
+			|| ! in_array( get_post_status( $current_post ), array( 'publish', 'inherit', 'trash' ), true )
 			|| ! is_post_type_viewable( $current_post->post_type )
 			// Skip purge if it is a new attachment.
 			|| ( 'attachment' === $current_post->post_type && $current_post->post_date === $current_post->post_modified )
@@ -198,12 +198,12 @@ class Cache {
 			return $post_purge_urls;
 		}
 
-		$post_purge_urls[] = get_permalink( $post_id );
+		$post_purge_urls[] = get_permalink( $current_post );
 		$post_purge_urls[] = home_url( '/' );
 
 		// Don't just purge the attachment page, but also include the file itself.
 		if ( 'attachment' === $current_post->post_type ) {
-			$post_purge_urls[] = wp_get_attachment_url( $post_id );
+			$post_purge_urls[] = wp_get_attachment_url( $current_post->ID );
 		}
 
 		$taxonomies = get_object_taxonomies( $current_post, 'object' );
@@ -214,7 +214,7 @@ class Cache {
 			}
 
 			$taxonomy_name = $taxonomy->name;
-			$terms         = get_the_terms( $post_id, $taxonomy_name );
+			$terms         = get_the_terms( $current_post, $taxonomy_name );
 
 			if ( false === $terms ) {
 				continue;
@@ -226,7 +226,7 @@ class Cache {
 		}
 
 		// Purge author urls.
-		$post_author_id  = get_post_field( 'post_author', $post_id );
+		$post_author_id  = get_post_field( 'post_author', $current_post );
 		$user_purge_urls = $this->get_user_purge_urls( $post_author_id );
 
 		// Purge the standard site feeds.
@@ -237,7 +237,7 @@ class Cache {
 			get_bloginfo( 'atom_url' ),
 			get_bloginfo( 'comments_atom_url' ),
 			get_bloginfo( 'comments_rss2_url' ),
-			get_post_comments_feed_link( $post_id ),
+			get_post_comments_feed_link( $current_post->ID ),
 		];
 
 		return array_merge( $post_purge_urls, $user_purge_urls, $site_feeds );

--- a/inc/class-cache.php
+++ b/inc/class-cache.php
@@ -379,6 +379,13 @@ class Cache {
 			return;
 		}
 
+		/**
+		 * Trigger pre-purge action to hook into URLs about to be purged.
+		 *
+		 * @param array self::$purge_queue List of URLs that will be purged.
+		 */
+		do_action( 'wp_irving_cache_pre_purge', self::$purge_queue );
+
 		// Fire the request to bust both VIP and Irving Redis cache.
 		wp_remote_post(
 			home_url( '/purge-cache' ),

--- a/inc/class-cache.php
+++ b/inc/class-cache.php
@@ -20,6 +20,13 @@ class Cache {
 	protected static $instance;
 
 	/**
+	 * Array of URLs that have already been purged.
+	 *
+	 * @var array
+	 */
+	public $purged_urls = [];
+
+	/**
 	 * Get class instance
 	 *
 	 * @return self
@@ -392,7 +399,11 @@ class Cache {
 	 */
 	public function fire_bulk_purge_request( $permalinks = [] ) {
 		foreach ( $permalinks as $permalink ) {
-			$this->fire_purge_request( $permalink );
+			// Prevent purges from firing twice if multiple actions are triggered.
+			if ( ! in_array( $permalink, $this->purged_urls, true ) ) {
+				array_push( $this->purged_urls, $permalink );
+				$this->fire_purge_request( $permalink );
+			}
 		}
 	}
 

--- a/inc/class-cache.php
+++ b/inc/class-cache.php
@@ -424,7 +424,9 @@ class Cache {
 		}
 
 		// Fire the request to bust both VIP and Irving Redis cache.
-		$response = wp_remote_request( $permalink, [ 'method' => 'PURGE' ] );
+		$response = wp_remote_get( add_query_arg( 'url', $permalink, home_url( '/purge-cache' ) ) );
+		wpcom_vip_purge_edge_cache_for_url( $permalink );
+
 		// Temp debugging.
 		if ( $response instanceof \WP_Error ) {
 			update_option( 'debug_purge_response', $response->get_error_message() );

--- a/inc/class-cache.php
+++ b/inc/class-cache.php
@@ -8,14 +8,34 @@
 namespace WP_Irving;
 
 /**
- * Class to purge cache.
+ * Class for managing caches in Irving.
  */
-class Purge_Cache {
+class Cache {
+
+	/**
+	 * Class instance.
+	 *
+	 * @var null|self
+	 */
+	protected static $instance;
+
+	/**
+	 * Get class instance
+	 *
+	 * @return self
+	 */
+	public static function instance() {
+		if ( ! isset( static::$instance ) ) {
+			static::$instance = new static();
+			static::$instance->setup();
+		}
+		return static::$instance;
+	}
 
 	/**
 	 * Class constructor.
 	 */
-	public function __construct() {
+	public function setup() {
 		// Register admin page.
 		add_action( 'admin_menu', [ $this, 'register_admin' ] );
 
@@ -195,6 +215,6 @@ class Purge_Cache {
 add_action(
 	'init',
 	function() {
-		new \WP_Irving\Purge_Cache();
+		( new \WP_Irving\Cache )->instance();
 	}
 );

--- a/inc/integrations/class-pantheon.php
+++ b/inc/integrations/class-pantheon.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * WP Irving integration for VIP Go.
+ *
+ * @package WP_Irving;
+ */
+
+namespace WP_Irving;
+
+/**
+ * Class to handle modifications specific to VIP Go.
+ */
+class Pantheon {
+
+	/**
+	 * Constructor for class.
+	 */
+	public function __construct() {
+		print_r('hi');
+	}
+}
+
+add_action(
+	'init',
+	function() {
+		new \WP_Irving\Pantheon();
+	}
+);

--- a/inc/integrations/class-pantheon.php
+++ b/inc/integrations/class-pantheon.php
@@ -158,7 +158,7 @@ class Pantheon {
 	 * @param int\WP_Post $post Post object or ID.
 	 */
 	public function get_and_purge_post_endpoints( $post ) {
-		$purge_urls = $this->convert_urls_to_endpoints( \WP_Irving\Cache::instance()->get_post_purge_urls( $post ) );
+		$purge_urls = $this->convert_urls_to_endpoint_paths( \WP_Irving\Cache::instance()->get_post_purge_urls( $post ) );
 		pantheon_wp_clear_edge_paths( $purge_urls );
 	}
 
@@ -168,7 +168,7 @@ class Pantheon {
 	 * @param int\WP_Term $term Term object or ID.
 	 */
 	public function get_and_purge_term_endpoints( $term ) {
-		$purge_urls = $this->convert_urls_to_endpoints( \WP_Irving\Cache::instance()->get_term_purge_urls( $term ) );
+		$purge_urls = $this->convert_urls_to_endpoint_paths( \WP_Irving\Cache::instance()->get_term_purge_urls( $term ) );
 		pantheon_wp_clear_edge_paths( $purge_urls );
 	}
 
@@ -178,7 +178,7 @@ class Pantheon {
 	 * @param int\WP_User $user user object or ID.
 	 */
 	public function get_and_purge_user_endpoints( $user ) {
-		$purge_urls = $this->convert_urls_to_endpoints( \WP_Irving\Cache::instance()->get_user_purge_urls( $user ) );
+		$purge_urls = $this->convert_urls_to_endpoint_paths( \WP_Irving\Cache::instance()->get_user_purge_urls( $user ) );
 		pantheon_wp_clear_edge_paths( $purge_urls );
 	}
 
@@ -188,7 +188,7 @@ class Pantheon {
 	 * @param array $urls Permalinks to purge.
 	 * @return array
 	 */
-	public function convert_urls_to_endpoints( $urls ) {
+	public function convert_urls_to_endpoint_paths( $urls ) {
 		$endpoint_urls = [];
 
 		foreach ( $urls as $url ) {
@@ -200,7 +200,13 @@ class Pantheon {
 			$endpoint_urls[] = \WP_Irving\REST_API\Components_Endpoint::get_wp_irving_api_url( $url, 'page' );
 		}
 
-		return $endpoint_urls;
+		// Only return paths.
+		return array_map(
+			function ( $endpoint ) {
+				return str_replace( site_url(), '', $endpoint );
+			},
+			$endpoint_urls
+		);
 	}
 
 	/**

--- a/inc/integrations/class-pantheon.php
+++ b/inc/integrations/class-pantheon.php
@@ -22,7 +22,7 @@ class Pantheon {
 	/**
 	 * Clear the cache for the entire site.
 	 *
-	 * @return void
+	 * @return bool
 	 */
 	public function pantheon_flush_site() {
 		if ( ! function_exists( 'current_user_can' ) || false == current_user_can( 'manage_options' ) ) {

--- a/inc/integrations/class-pantheon.php
+++ b/inc/integrations/class-pantheon.php
@@ -23,162 +23,17 @@ class Pantheon {
 		add_action( 'admin_post_pantheon_cache_flush_site', [ $this, 'pantheon_flush_site' ], 9 );
 
 		// Post purging actions.
-		add_action( 'wp_insert_post', [ $this, 'on_update_post' ], 10, 2 );
-		add_action( 'clean_post_cache', [ $this, 'on_clean_post_cache' ], 10, 2 );
-		add_action( 'transition_post_status', [ $this, 'on_post_status_transition' ], 10, 3 );
-		add_action( 'before_delete_post', [ $this, 'on_before_delete_post' ] );
-		add_action( 'delete_attachment', [ $this, 'on_delete_attachment' ] );
+		add_action( 'wp_irving_cache_pre_purge', [ $this, 'purge_endpoint_urls' ], 10, 2 );
 
-		// Term purging actions.
-		add_action( 'created_term', [ $this, 'on_created_term' ], 10, 3 );
-		add_action( 'edited_term', [ $this, 'on_edited_term' ] );
-		add_action( 'delete_term', [ $this, 'on_delete_term' ] );
-		add_action( 'clean_term_cache', [ $this, 'on_clean_term_cache' ] );
-
-		// User purging actions.
-		add_action( 'clean_user_cache', [ $this, 'on_clean_user_cache' ] );
 	}
 
 	/**
-	 * Purge cache on post update.
+	 * Hook into core cache and purge endpoint caches on pantheon as well.
 	 *
-	 * @param int     $post_id Post ID.
-	 * @param WP_Post $post    Post object.
+	 * @param array $purge_queue Array of URLs about to be purged in Redis.
 	 */
-	public function on_update_post( $post_id, $post ) {
-		if ( 'publish' !== $post->post_status ) {
-			return;
-		}
-
-		// Purge cache.
-		$this->get_and_purge_post_endpoints( $post_id );
-	}
-
-	/**
-	 * Purge cache on post cache clear.
-	 *
-	 * @param int     $post_id Post ID.
-	 * @param WP_Post $post    Post object.
-	 */
-	public function on_clean_post_cache( $post_id, $post ) {
-		if ( 'publish' !== $post->post_status ) {
-			return;
-		}
-
-		// Purge cache.
-		$this->get_and_purge_post_endpoints( $post_id );
-	}
-
-	/**
-	 * Purge cache on page transition.
-	 *
-	 * @param string  $new_status New Status.
-	 * @param string  $old_status Old Status.
-	 * @param WP_Post $post       Post object.
-	 */
-	public function on_post_status_transition( $new_status, $old_status, $post ) {
-		if ( 'publish' !== $new_status && 'publish' !== $old_status ) {
-			return;
-		}
-
-		// Purge cache.
-		$this->get_and_purge_post_endpoints( $post );
-	}
-
-	/**
-	 * Purge on post delete.
-	 *
-	 * @param int $post_id Post ID.
-	 */
-	public function on_before_delete_post( $post_id ) {
-		$this->get_and_purge_post_endpoints( $post_id );
-	}
-
-	/**
-	 * Purge attachment on delete.
-	 *
-	 * @param int $post_id Post ID.
-	 */
-	public function on_delete_attachment( $post_id ) {
-		$this->get_and_purge_post_endpoints( $post_id );
-	}
-
-	/**
-	 * Purge term cache on create.
-	 *
-	 * @param int\WP_Term $term_id Term ID.
-	 */
-	public function on_created_term( $term_id ) {
-		$this->get_and_purge_term_endpoints( $term_id );
-	}
-
-	/**
-	 * Purge term cache on edit.
-	 *
-	 * @param int\WP_Term $term_id Term ID.
-	 */
-	public function on_edited_term( $term_id ) {
-		$this->get_and_purge_term_endpoints( $term_id );
-	}
-
-	/**
-	 * Purge term cache on delete.
-	 *
-	 * @param int\WP_Term $term_id Term ID.
-	 */
-	public function on_deleted_term( $term_id ) {
-		$this->get_and_purge_term_endpoints( $term_id );
-	}
-
-	/**
-	 * Purge terms on clean cache.
-	 *
-	 * @param array $term_ids Term IDs.
-	 */
-	public function on_clean_term_cache( $term_ids ) {
-		$ids = is_array( $term_ids ) ? $term_ids : array( $term_ids );
-
-		foreach ( $ids as $term_id ) {
-			$this->get_and_purge_term_endpoints( $term_id );
-		}
-	}
-
-	/**
-	 * Purge user on clean cache.
-	 *
-	 * @param array $user_id User ID.
-	 */
-	public function on_clean_user_cache( $user_id ) {
-		$this->get_and_purge_user_endpoints( $user_id );
-	}
-
-	/**
-	 * Get and purge post endpoints.
-	 *
-	 * @param int\WP_Post $post Post object or ID.
-	 */
-	public function get_and_purge_post_endpoints( $post ) {
-		$purge_urls = $this->convert_urls_to_endpoint_paths( \WP_Irving\Cache::instance()->get_post_purge_urls( $post ) );
-		pantheon_wp_clear_edge_paths( $purge_urls );
-	}
-
-	/**
-	 * Get and purge term endpoints.
-	 *
-	 * @param int\WP_Term $term Term object or ID.
-	 */
-	public function get_and_purge_term_endpoints( $term ) {
-		$purge_urls = $this->convert_urls_to_endpoint_paths( \WP_Irving\Cache::instance()->get_term_purge_urls( $term ) );
-		pantheon_wp_clear_edge_paths( $purge_urls );
-	}
-
-	/**
-	 * Get and purge user endpoints.
-	 *
-	 * @param int\WP_User $user user object or ID.
-	 */
-	public function get_and_purge_user_endpoints( $user ) {
-		$purge_urls = $this->convert_urls_to_endpoint_paths( \WP_Irving\Cache::instance()->get_user_purge_urls( $user ) );
+	public function purge_endpoint_urls( $purge_queue ) {
+		$purge_urls = $this->convert_urls_to_endpoint_paths( $purge_queue );
 		pantheon_wp_clear_edge_paths( $purge_urls );
 	}
 
@@ -192,10 +47,6 @@ class Pantheon {
 		$endpoint_urls = [];
 
 		foreach ( $urls as $url ) {
-			if ( false === strpos( $url, home_url() ) ) {
-				continue;
-			}
-
 			$endpoint_urls[] = \WP_Irving\REST_API\Components_Endpoint::get_wp_irving_api_url( $url, 'site' );
 			$endpoint_urls[] = \WP_Irving\REST_API\Components_Endpoint::get_wp_irving_api_url( $url, 'page' );
 		}

--- a/inc/integrations/class-pantheon.php
+++ b/inc/integrations/class-pantheon.php
@@ -16,7 +16,22 @@ class Pantheon {
 	 * Constructor for class.
 	 */
 	public function __construct() {
+		add_action( 'admin_post_pantheon_cache_flush_site', [ $this, 'pantheon_flush_site' ], 9 );
+	}
 
+	/**
+	 * Clear the cache for the entire site.
+	 *
+	 * @return void
+	 */
+	public function pantheon_flush_site() {
+		if ( ! function_exists( 'current_user_can' ) || false == current_user_can( 'manage_options' ) ) {
+			return false;
+		}
+
+		if ( ! empty( $_POST['pantheon-cache-nonce'] ) && wp_verify_nonce( $_POST['pantheon-cache-nonce'], 'pantheon-cache-clear-all' ) ) {
+			\WP_Irving\Cache::instance()->fire_wipe_request();
+		}
 	}
 }
 

--- a/inc/integrations/class-pantheon.php
+++ b/inc/integrations/class-pantheon.php
@@ -16,7 +16,7 @@ class Pantheon {
 	 * Constructor for class.
 	 */
 	public function __construct() {
-		print_r('hi');
+
 	}
 }
 

--- a/inc/integrations/class-pantheon.php
+++ b/inc/integrations/class-pantheon.php
@@ -219,6 +219,7 @@ class Pantheon {
 			return false;
 		}
 
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 		if ( ! empty( $_POST['pantheon-cache-nonce'] ) && wp_verify_nonce( $_POST['pantheon-cache-nonce'], 'pantheon-cache-clear-all' ) ) {
 			\WP_Irving\Cache::instance()->fire_wipe_request();
 		}

--- a/inc/integrations/class-pantheon.php
+++ b/inc/integrations/class-pantheon.php
@@ -16,7 +16,191 @@ class Pantheon {
 	 * Constructor for class.
 	 */
 	public function __construct() {
+		if ( ! function_exists( 'pantheon_wp_clear_edge_paths' ) ) {
+			return;
+		}
+
 		add_action( 'admin_post_pantheon_cache_flush_site', [ $this, 'pantheon_flush_site' ], 9 );
+
+		// Post purging actions.
+		add_action( 'wp_insert_post', [ $this, 'on_update_post' ], 10, 2 );
+		add_action( 'clean_post_cache', [ $this, 'on_clean_post_cache' ], 10, 2 );
+		add_action( 'transition_post_status', [ $this, 'on_post_status_transition' ], 10, 3 );
+		add_action( 'before_delete_post', [ $this, 'on_before_delete_post' ] );
+		add_action( 'delete_attachment', [ $this, 'on_delete_attachment' ] );
+
+		// Term purging actions.
+		add_action( 'created_term', [ $this, 'on_created_term' ], 10, 3 );
+		add_action( 'edited_term', [ $this, 'on_edited_term' ] );
+		add_action( 'delete_term', [ $this, 'on_delete_term' ] );
+		add_action( 'clean_term_cache', [ $this, 'on_clean_term_cache' ] );
+
+		// User purging actions.
+		add_action( 'clean_user_cache', [ $this, 'on_clean_user_cache' ] );
+	}
+
+	/**
+	 * Purge cache on post update.
+	 *
+	 * @param int     $post_id Post ID.
+	 * @param WP_Post $post    Post object.
+	 */
+	public function on_update_post( $post_id, $post ) {
+		if ( 'publish' !== $post->post_status ) {
+			return;
+		}
+
+		// Purge cache.
+		$this->get_and_purge_post_endpoints( $post_id );
+	}
+
+	/**
+	 * Purge cache on post cache clear.
+	 *
+	 * @param int     $post_id Post ID.
+	 * @param WP_Post $post    Post object.
+	 */
+	public function on_clean_post_cache( $post_id, $post ) {
+		if ( 'publish' !== $post->post_status ) {
+			return;
+		}
+
+		// Purge cache.
+		$this->get_and_purge_post_endpoints( $post_id );
+	}
+
+	/**
+	 * Purge cache on page transition.
+	 *
+	 * @param string  $new_status New Status.
+	 * @param string  $old_status Old Status.
+	 * @param WP_Post $post       Post object.
+	 */
+	public function on_post_status_transition( $new_status, $old_status, $post ) {
+		if ( 'publish' !== $new_status && 'publish' !== $old_status ) {
+			return;
+		}
+
+		// Purge cache.
+		$this->get_and_purge_post_endpoints( $post );
+	}
+
+	/**
+	 * Purge on post delete.
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	public function on_before_delete_post( $post_id ) {
+		$this->get_and_purge_post_endpoints( $post_id );
+	}
+
+	/**
+	 * Purge attachment on delete.
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	public function on_delete_attachment( $post_id ) {
+		$this->get_and_purge_post_endpoints( $post_id );
+	}
+
+	/**
+	 * Purge term cache on create.
+	 *
+	 * @param int\WP_Term $term_id Term ID.
+	 */
+	public function on_created_term( $term_id ) {
+		$this->get_and_purge_term_endpoints( $term_id );
+	}
+
+	/**
+	 * Purge term cache on edit.
+	 *
+	 * @param int\WP_Term $term_id Term ID.
+	 */
+	public function on_edited_term( $term_id ) {
+		$this->get_and_purge_term_endpoints( $term_id );
+	}
+
+	/**
+	 * Purge term cache on delete.
+	 *
+	 * @param int\WP_Term $term_id Term ID.
+	 */
+	public function on_deleted_term( $term_id ) {
+		$this->get_and_purge_term_endpoints( $term_id );
+	}
+
+	/**
+	 * Purge terms on clean cache.
+	 *
+	 * @param array $term_ids Term IDs.
+	 */
+	public function on_clean_term_cache( $term_ids ) {
+		$ids = is_array( $term_ids ) ? $term_ids : array( $term_ids );
+
+		foreach ( $ids as $term_id ) {
+			$this->get_and_purge_term_endpoints( $term_id );
+		}
+	}
+
+	/**
+	 * Purge user on clean cache.
+	 *
+	 * @param array $user_id User ID.
+	 */
+	public function on_clean_user_cache( $user_id ) {
+		$this->get_and_purge_user_endpoints( $user_id );
+	}
+
+	/**
+	 * Get and purge post endpoints.
+	 *
+	 * @param int\WP_Post $post Post object or ID.
+	 */
+	public function get_and_purge_post_endpoints( $post ) {
+		$purge_urls = $this->convert_urls_to_endpoints( \WP_Irving\Cache::instance()->get_post_purge_urls( $post ) );
+		pantheon_wp_clear_edge_paths( $purge_urls );
+	}
+
+	/**
+	 * Get and purge term endpoints.
+	 *
+	 * @param int\WP_Term $term Term object or ID.
+	 */
+	public function get_and_purge_term_endpoints( $term ) {
+		$purge_urls = $this->convert_urls_to_endpoints( \WP_Irving\Cache::instance()->get_term_purge_urls( $term ) );
+		pantheon_wp_clear_edge_paths( $purge_urls );
+	}
+
+	/**
+	 * Get and purge user endpoints.
+	 *
+	 * @param int\WP_User $user user object or ID.
+	 */
+	public function get_and_purge_user_endpoints( $user ) {
+		$purge_urls = $this->convert_urls_to_endpoints( \WP_Irving\Cache::instance()->get_user_purge_urls( $user ) );
+		pantheon_wp_clear_edge_paths( $purge_urls );
+	}
+
+	/**
+	 * Convert permalinks into Irving endpoint URLs.
+	 *
+	 * @param array $urls Permalinks to purge.
+	 * @return array
+	 */
+	public function convert_urls_to_endpoints( $urls ) {
+		$endpoint_urls = [];
+
+		foreach ( $urls as $url ) {
+			if ( false === strpos( $url, home_url() ) ) {
+				continue;
+			}
+
+			$endpoint_urls[] = \WP_Irving\REST_API\Components_Endpoint::get_wp_irving_api_url( $url, 'site' );
+			$endpoint_urls[] = \WP_Irving\REST_API\Components_Endpoint::get_wp_irving_api_url( $url, 'page' );
+		}
+
+		return $endpoint_urls;
 	}
 
 	/**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -30,8 +30,14 @@ require_once $_tests_dir . '/includes/functions.php';
  */
 function _manually_load_plugin() {
 	require dirname( dirname( __FILE__ ) ) . '/wp-irving.php';
-	require dirname( __DIR__, 2 ) . '/safe-redirect-manager/safe-redirect-manager.php';
-	require dirname( __DIR__, 2 ) . '/wpcom-legacy-redirector/wpcom-legacy-redirector.php';
+
+	if ( class_exists( 'SRM_Redirect' ) ) {
+		require dirname( __DIR__, 2 ) . '/safe-redirect-manager/safe-redirect-manager.php';
+	}
+
+	if ( class_exists( 'WPCOM_Legacy_Redirector' ) ) {
+		require dirname( __DIR__, 2 ) . '/wpcom-legacy-redirector/wpcom-legacy-redirector.php';
+	}
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -30,7 +30,6 @@ require_once $_tests_dir . '/includes/functions.php';
  */
 function _manually_load_plugin() {
 	update_option( 'permalink_structure', '/%year%/%monthnum%/%day%/%postname%/' );
-	require dirname( dirname( __FILE__ ) ) . '/wp-irving.php';
 
 	$paths = [
 		dirname( dirname( __FILE__ ) ) . '/wp-irving.php',

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -29,6 +29,7 @@ require_once $_tests_dir . '/includes/functions.php';
  * Manually load the plugin being tested.
  */
 function _manually_load_plugin() {
+	update_option( 'permalink_structure', '/%year%/%monthnum%/%day%/%postname%/' );
 	require dirname( dirname( __FILE__ ) ) . '/wp-irving.php';
 
 	if ( class_exists( 'SRM_Redirect' ) ) {

--- a/tests/test-cache.php
+++ b/tests/test-cache.php
@@ -77,13 +77,6 @@ class Cache_Tests extends WP_UnitTestCase {
 				'http://example.org/?tag=' . $current_term->slug . '/feed/',
 				'http://example.org/author/' . $current_user->data->user_login . '/',
 				'http://example.org/author/' . $current_user->data->user_login . '/feed/',
-				'http://example.org/feed/rdf/',
-				'http://example.org/feed/rss/',
-				'http://example.org/feed/',
-				'http://example.org/feed/atom/',
-				'http://example.org/comments/feed/atom/',
-				'http://example.org/comments/feed/',
-				'http://example.org/2020/01/01/' . $current_post->post_title . '/feed/',
 			]
 		);
 	}

--- a/tests/test-cache.php
+++ b/tests/test-cache.php
@@ -35,9 +35,6 @@ class Cache_Tests extends WP_UnitTestCase {
 	 * Test suite setup.
 	 */
 	public static function setUpBeforeClass() {
-		global $wp_rewrite;
-		$wp_rewrite->set_permalink_structure( '/%year%/%monthnum%/%day%/%postname%/' );
-
 		self::$helpers = new \WP_Irving\Test_Helpers();
 		self::$cache   = \WP_Irving\Cache::instance();
 	}
@@ -71,10 +68,10 @@ class Cache_Tests extends WP_UnitTestCase {
 			[
 				'http://example.org/2020/01/01/' . $current_post->post_title . '/',
 				'http://example.org/',
-				'http://example.org/?cat=1',
-				'http://example.org/?cat=1/feed/',
-				'http://example.org/?tag=' . $current_term->slug,
-				'http://example.org/?tag=' . $current_term->slug . '/feed/',
+				'http://example.org/category/uncategorized' . '/',
+				'http://example.org/category/uncategorized/feed/',
+				'http://example.org/tag/' . $current_term->slug . '/',
+				'http://example.org/tag/' . $current_term->slug . '/feed/',
 				'http://example.org/author/' . $current_user->data->user_login . '/',
 				'http://example.org/author/' . $current_user->data->user_login . '/feed/',
 			]
@@ -95,8 +92,8 @@ class Cache_Tests extends WP_UnitTestCase {
 		$this->assertEquals(
 			self::$cache->get_term_purge_urls( $current_term->term_id ),
 			[
-				'http://example.org/?cat=' . $current_term->term_id,
-				'http://example.org/?cat=' . $current_term->term_id . '/feed/',
+				'http://example.org/category/' . $current_term->slug . '/',
+				'http://example.org/category/' . $current_term->slug . '/feed/',
 			]
 		);
 	}

--- a/tests/test-cache.php
+++ b/tests/test-cache.php
@@ -64,7 +64,6 @@ class Cache_Tests extends WP_UnitTestCase {
 				'taxonomy' => 'post_tag',
 			]
 		);
-		// print_r( $current_term );
 		$this->factory->term->add_post_terms( $current_post->ID, [ $current_term->slug ], 'post_tag' );
 
 		$this->assertEquals(

--- a/tests/test-cache.php
+++ b/tests/test-cache.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Class Cache_Tests
+ *
+ * @package WP_Irving
+ */
+
+/**
+ * Tests for integration with WPCOM Legacy Redirector.
+ */
+class Cache_Tests extends WP_UnitTestCase {
+
+	/**
+	 * Helpers class instance.
+	 *
+	 * \WP_Irving_Test_Helpers
+	 */
+	static $helpers;
+
+	/**
+	 * Helpers class instance.
+	 *
+	 * \WP_Irving\Cache
+	 */
+	static $cache;
+
+	/**
+	 * Components endpoint instance.
+	 *
+	 * \WP_Irving\REST_API\Components_Endpoint
+	 */
+	static $components_endpoint;
+
+	/**
+	 * Test suite setup.
+	 */
+	public static function setUpBeforeClass() {
+		self::$helpers = new \WP_Irving\Test_Helpers();
+		self::$cache   = \WP_Irving\Cache::instance();
+	}
+
+	/**
+	 * Test post purge urls.
+	 */
+	public function test_get_post_purge_urls() {
+		// insert a post.
+		$current_post = $this->factory->post->create_and_get(
+			array(
+				'post_title' => rand_str(),
+				'post_date'  => '2020-01-01 00:00:00',
+			)
+		);
+	}
+}

--- a/tests/test-cache.php
+++ b/tests/test-cache.php
@@ -35,6 +35,9 @@ class Cache_Tests extends WP_UnitTestCase {
 	 * Test suite setup.
 	 */
 	public static function setUpBeforeClass() {
+		global $wp_rewrite;
+		$wp_rewrite->set_permalink_structure( '/%year%/%monthnum%/%day%/%postname%/' );
+
 		self::$helpers = new \WP_Irving\Test_Helpers();
 		self::$cache   = \WP_Irving\Cache::instance();
 	}
@@ -43,12 +46,85 @@ class Cache_Tests extends WP_UnitTestCase {
 	 * Test post purge urls.
 	 */
 	public function test_get_post_purge_urls() {
-		// insert a post.
+		$current_user = $this->factory->user->create_and_get(
+			[
+				'user_login'  => 'alley',
+			]
+		);
 		$current_post = $this->factory->post->create_and_get(
-			array(
-				'post_title' => rand_str(),
-				'post_date'  => '2020-01-01 00:00:00',
-			)
+			[
+				'post_title'  => rand_str(),
+				'post_date'   => '2020-01-01 00:00:00',
+				'post_author' => $current_user->ID,
+			]
+		);
+		$current_term = $this->factory->term->create_and_get(
+			[
+				'name'     => 'Test',
+				'taxonomy' => 'post_tag',
+			]
+		);
+		// print_r( $current_term );
+		$this->factory->term->add_post_terms( $current_post->ID, [ $current_term->slug ], 'post_tag' );
+
+		$this->assertEquals(
+			self::$cache->get_post_purge_urls( $current_post->ID ),
+			[
+				'http://example.org/2020/01/01/' . $current_post->post_title . '/',
+				'http://example.org/',
+				'http://example.org/?cat=1',
+				'http://example.org/?cat=1/feed/',
+				'http://example.org/?tag=' . $current_term->slug,
+				'http://example.org/?tag=' . $current_term->slug . '/feed/',
+				'http://example.org/author/' . $current_user->data->user_login . '/',
+				'http://example.org/author/' . $current_user->data->user_login . '/feed/',
+				'http://example.org/feed/rdf/',
+				'http://example.org/feed/rss/',
+				'http://example.org/feed/',
+				'http://example.org/feed/atom/',
+				'http://example.org/comments/feed/atom/',
+				'http://example.org/comments/feed/',
+				'http://example.org/2020/01/01/' . $current_post->post_title . '/feed/',
+			]
+		);
+	}
+
+	/**
+	 * Test term purge urls.
+	 */
+	public function test_get_term_purge_urls() {
+		$current_term = $this->factory->term->create_and_get(
+			[
+				'name'     => 'Test',
+				'taxonomy' => 'category',
+			]
+		);
+
+		$this->assertEquals(
+			self::$cache->get_term_purge_urls( $current_term->term_id ),
+			[
+				'http://example.org/?cat=' . $current_term->term_id,
+				'http://example.org/?cat=' . $current_term->term_id . '/feed/',
+			]
+		);
+	}
+
+	/**
+	 * Test user purge urls.
+	 */
+	public function test_get_user_purge_urls() {
+		$current_user = $this->factory->user->create_and_get(
+			[
+				'user_login'  => 'alley',
+			]
+		);
+
+		$this->assertEquals(
+			self::$cache->get_user_purge_urls( $current_user ),
+			[
+				'http://example.org/author/' . $current_user->data->user_login . '/',
+				'http://example.org/author/' . $current_user->data->user_login . '/feed/',
+			]
 		);
 	}
 }

--- a/tests/test-legacy-redirector.php
+++ b/tests/test-legacy-redirector.php
@@ -47,15 +47,6 @@ class Legacy_Redirector_Tests extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Set up tets.
-	 */
-	public function setUp() {
-        if ( ! class_exists( 'WPCOM_Legacy_Redirector' ) ) {
-            $this->markTestSkipped( 'WPCOM_Legacy_Redirector is not available.' );
-        }
-    }
-
-	/**
 	 * Test relative redirect.
 	 */
 	public function test_relative_to_relative() {

--- a/tests/test-legacy-redirector.php
+++ b/tests/test-legacy-redirector.php
@@ -34,6 +34,15 @@ class Legacy_Redirector_Tests extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Set up tets.
+	 */
+	public function setUp() {
+        if ( ! class_exists( 'WPCOM_Legacy_Redirector' ) ) {
+            $this->markTestSkipped( 'WPCOM_Legacy_Redirector is not available.' );
+        }
+    }
+
+	/**
 	 * Test relative redirect.
 	 */
 	public function test_relative_to_relative() {

--- a/tests/test-safe-redirect-manager.php
+++ b/tests/test-safe-redirect-manager.php
@@ -41,6 +41,11 @@ class Safe_Redirect_Manager_Tests extends WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
+		if ( ! class_exists( 'SRM_Redirect' ) ) {
+			$this->markTestSkipped( 'SRM_Redirect is not available.' );
+			return;
+        }
+
 		$this->object = \SRM_Redirect::factory();
 	}
 

--- a/wp-irving.php
+++ b/wp-irving.php
@@ -34,13 +34,14 @@ require_once WP_IRVING_PATH . '/inc/integrations/class-jwt-auth.php';
 require_once WP_IRVING_PATH . '/inc/integrations/class-new-relic.php';
 require_once WP_IRVING_PATH . '/inc/integrations/class-safe-redirect-manager.php';
 require_once WP_IRVING_PATH . '/inc/integrations/class-vip-go.php';
+require_once WP_IRVING_PATH . '/inc/integrations/class-pantheon.php';
 require_once WP_IRVING_PATH . '/inc/integrations/class-wpcom-legacy-redirector.php';
 require_once WP_IRVING_PATH . '/inc/integrations/class-yoast.php';
 
 // Replicating WP Core functionality.
 require_once WP_IRVING_PATH . '/inc/class-admin.php';
 require_once WP_IRVING_PATH . '/inc/class-previews.php';
-require_once WP_IRVING_PATH . '/inc/class-purge-cache.php';
+require_once WP_IRVING_PATH . '/inc/class-cache.php';
 
 // Redirects.
 require_once WP_IRVING_PATH . '/inc/redirects.php';


### PR DESCRIPTION
[**IRV-262**](https://alleyinteractive.atlassian.net/browse/IRV-262)

This PR will:
* Rename `Purge_Cache` to just `Cache`
* Add functionality to core `Cache` class that:
  * Purges posts on various post-related actions, including related terms and users
  * Purges terms on various term-related actions
  * Purges users on user-related actions
* Add a Pantheon integration that, on the appropriate actions, will collect and purge endpoint URLs via Pantheon's advanced page cache plugin.
* Add some initial unit tests for the core `Cache` class
* Skip SRM and Legacy Redirector tests if those plugins aren't loaded