### PR TITLE
Refactor SRM integration to use 10up version of plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ before_script:
   - |
     if [[ ! -z "$WP_VERSION" ]] ; then
       cd ../
-      git clone https://github.com/alleyinteractive/safe-redirect-manager.git
+      git clone https://github.com/10up/safe-redirect-manager.git
       git clone https://github.com/Automattic/WPCOM-Legacy-Redirector.git wpcom-legacy-redirector
       cd wp-irving
     fi

--- a/inc/integrations/class-safe-redirect-manager.php
+++ b/inc/integrations/class-safe-redirect-manager.php
@@ -31,7 +31,7 @@ class Safe_Redirect_Manager {
 	 */
 	public function __construct() {
 		// Ensure Safe Redirect Manager exists and is enabled.
-		if ( ! class_exists( '\SRM_Redirect' ) || ! method_exists( '\SRM_Redirect', 'get_redirect_match' ) ) {
+		if ( ! class_exists( '\SRM_Redirect' ) || ! method_exists( '\SRM_Redirect', 'match_redirect' ) ) {
 			return;
 		}
 
@@ -54,16 +54,15 @@ class Safe_Redirect_Manager {
 	 * @param string            $path     Request path parameter.
 	 * @param \WP_REST_Response $request  REST request.
 	 */
-	public function get_srm_redirect( $data, $query, $context, $path, $request ) : array {
+	public function get_srm_redirect( $data, $query, $context, $path, $request ): array {
 		// Store request path.
 		$this->params = $request->get_params();
 
-		// Filter the path and redirect values.
-		add_filter( 'srm_requested_path', [ $this, 'set_srm_requested_path' ] );
+		// Filter the redirect value.
 		add_filter( 'srm_redirect_to', [ $this, 'set_srm_redirect_to' ] );
 
 		// Find matching redirect for current path.
-		$redirect_match = $this->srm->get_redirect_match();
+		$redirect_match = $this->srm->match_redirect( untrailingslashit( $this->params['path'] ) );
 
 		// Add redirect_to and status_code from SRM match.
 		$data['redirectTo'] = empty( $data['redirectTo'] ) ?
@@ -74,16 +73,6 @@ class Safe_Redirect_Manager {
 			$data['redirectStatus'];
 
 		return $data;
-	}
-
-	/**
-	 * Modify the requested path value to our path argument.
-	 *
-	 * @param  string $path Current path.
-	 * @return string Path parameter.
-	 */
-	public function set_srm_requested_path( string $path ) : string {
-		return $this->params['path'] ?? $path;
 	}
 
 	/**
@@ -102,6 +91,9 @@ class Safe_Redirect_Manager {
 	}
 }
 
-add_action( 'init', function() {
-	new \WP_Irving\Safe_Redirect_Manager();
-} );
+add_action(
+	'init',
+	function() {
+		new \WP_Irving\Safe_Redirect_Manager();
+	}
+);

--- a/tests/test-safe-redirect-manager.php
+++ b/tests/test-safe-redirect-manager.php
@@ -44,7 +44,7 @@ class Safe_Redirect_Manager_Tests extends WP_UnitTestCase {
 		if ( ! class_exists( 'SRM_Redirect' ) ) {
 			$this->markTestSkipped( 'SRM_Redirect is not available.' );
 			return;
-        }
+		}
 
 		$this->object = \SRM_Redirect::factory();
 	}
@@ -135,9 +135,9 @@ class Safe_Redirect_Manager_Tests extends WP_UnitTestCase {
 	}
 
 	public function markasIncomplete() {
-		if ( ! method_exists( $this->object, 'get_redirect_match' ) ) {
+		if ( ! method_exists( $this->object, 'match_redirect' ) ) {
 			$this->markTestIncomplete(
-				'get_redirect_match not part of Safe Redirect Manager.'
+				'match_redirect not part of Safe Redirect Manager.'
 			);
 		}
 	}


### PR DESCRIPTION
This PR makes the changes necessary to switch from the [Alley forked version of Safe Redirect Manager](https://github.com/alleyinteractive/safe-redirect-manager) to the [canonical 10up version](https://github.com/10up/safe-redirect-manager) (we were waiting on a PR to merge before doing so).

For any existing projects relying on the integration, updating WP Irving should be accompanied by a switch to the 10up plugin or redirects will break.