### PR TITLE
Add origin to cache request

### DIFF
--- a/inc/class-cache.php
+++ b/inc/class-cache.php
@@ -393,6 +393,7 @@ class Cache {
 				'body'    => json_encode( [ 'paths' => self::$purge_queue ] ),
 				'headers' => [
 					'Content-Type' => 'application/json; charset=utf-8',
+					'Origin'       => site_url(),
 				],
 			]
 		);


### PR DESCRIPTION
Question: Seems like this request should already have `site_url()` as its origin, am I missing something?