### PR TITLE
Begin implementing schema on components

### DIFF
--- a/inc/class-component.php
+++ b/inc/class-component.php
@@ -798,8 +798,8 @@ class Component implements JsonSerializable {
 		$this->set_config( 'theme_options', array_keys( $this->camel_case_keys( array_flip( $this->get_theme_options() ) ) ) );
 
 		// Null any config keys where the schema has hidden = true.
-		foreach ( $this->get_schema() as $key => $schmea ) {
-			if ( $schmea['hidden'] ) {
+		foreach ( $this->get_schema() as $key => $schema ) {
+			if ( $schema['hidden'] ) {
 				$this->set_config( $key, null );
 			}
 		}

--- a/inc/class-component.php
+++ b/inc/class-component.php
@@ -34,11 +34,20 @@ class Component implements JsonSerializable {
 	/**
 	 * Config schema.
 	 *
-	 * @todo Implement this.
-	 *
 	 * @var array
 	 */
 	protected $schema = [];
+
+	/**
+	 * Default schema for any given config.
+	 *
+	 * @var array
+	 */
+	protected $schema_shape = [
+		'default' => null,
+		'hidden'  => false,
+		'type'    => 'null',
+	];
 
 	/**
 	 * Children.
@@ -268,14 +277,7 @@ class Component implements JsonSerializable {
 
 		// Ensure that every schema has all the expected properties.
 		foreach ( $schema as $key => &$properties ) {
-			$properties = wp_parse_args(
-				$properties,
-				[
-					'default' => null,
-					'hidden'  => false,
-					'type'    => 'null',
-				]
-			);
+			$properties = wp_parse_args( $properties, $this->schema_shape );
 		}
 
 		$this->schema = $schema;

--- a/inc/class-component.php
+++ b/inc/class-component.php
@@ -36,14 +36,14 @@ class Component implements JsonSerializable {
 	 *
 	 * @var array
 	 */
-	protected $schema = [];
+	protected $config_schema = [];
 
 	/**
 	 * Default schema for any given config.
 	 *
 	 * @var array
 	 */
-	protected $schema_shape = [
+	protected $config_schema_shape = [
 		'default' => null,
 		'hidden'  => false,
 		'type'    => 'null',
@@ -114,7 +114,7 @@ class Component implements JsonSerializable {
 			$args,
 			[
 				'config'           => [],
-				'schema'           => [],
+				'config_schema'    => [],
 				'children'         => [],
 				'theme'            => 'default',
 				'theme_options'    => [ 'default' ],
@@ -127,8 +127,8 @@ class Component implements JsonSerializable {
 		// Set up config.
 		$this->set_config( $args['config'] );
 
-		// Set up schema.
-		$this->set_schema( $args['schema'] );
+		// Set up config_schema.
+		$this->set_config_schema( $args['config_schema'] );
 
 		// Set up children.
 		$this->set_children( $args['children'] );
@@ -259,28 +259,28 @@ class Component implements JsonSerializable {
 	}
 
 	/**
-	 * Get the schema.
+	 * Get the config schema.
 	 *
 	 * @return array
 	 */
-	public function get_schema() {
-		return $this->schema;
+	public function get_config_schema() {
+		return $this->config_schema;
 	}
 
 	/**
 	 * Set schema describing config.
 	 *
-	 * @param array $schema Schema array.
+	 * @param array $config_schema Schema array.
 	 * @return self
 	 */
-	public function set_schema( array $schema ): self {
+	public function set_config_schema( array $config_schema ): self {
 
 		// Ensure that every schema has all the expected properties.
-		foreach ( $schema as $key => &$properties ) {
-			$properties = wp_parse_args( $properties, $this->schema_shape );
+		foreach ( $config_schema as $key => &$properties ) {
+			$properties = wp_parse_args( $properties, $this->config_schema_shape );
 		}
 
-		$this->schema = $schema;
+		$this->config_schema = $config_schema;
 		return $this;
 	}
 
@@ -797,9 +797,9 @@ class Component implements JsonSerializable {
 		$this->set_config( 'theme_name', self::camel_case( $this->get_theme() ) );
 		$this->set_config( 'theme_options', array_keys( $this->camel_case_keys( array_flip( $this->get_theme_options() ) ) ) );
 
-		// Null any config keys where the schema has hidden = true.
-		foreach ( $this->get_schema() as $key => $schema ) {
-			if ( $schema['hidden'] ) {
+		// Null any config keys where the config schema has hidden = true.
+		foreach ( $this->get_config_schema() as $key => $config_schema ) {
+			if ( $config_schema['hidden'] ) {
 				$this->set_config( $key, null );
 			}
 		}

--- a/inc/templates.php
+++ b/inc/templates.php
@@ -401,14 +401,7 @@ function hydrate_components( array $components ) {
 		// Reset context to where it was before hydration.
 		get_template_context()->reset();
 
-		// Convert text nodes to actual text notes.
-		// @todo there's _definitely_ a better way to do this, but certain
-		// Irving core functionality won't work without this hack.
-		if ( 'irving/text' === $component->get_name() ) {
-			$hydrated[] = $component->get_config( 'content' );
-		} else {
-			$hydrated[] = $component->jsonSerialize();
-		}
+		$hydrated[] = $component->jsonSerialize();
 	};
 
 	return $hydrated;
@@ -528,6 +521,12 @@ function parse_config_from_registry( array $component ) {
 		$component[ $prop ] = $registered[ $prop ] ?? [];
 	}
 
+	// Set the schema.
+	if ( ! empty( $registered['config'] ?? [] ) ) {
+		$component['schema'] = $registered['config'];
+	}
+
+	// Set the theme options.
 	if ( ! empty( $registered['theme_options'] ?? [] ) ) {
 		$component['theme_options'] = $registered['theme_options'];
 	}

--- a/inc/templates.php
+++ b/inc/templates.php
@@ -526,7 +526,7 @@ function parse_config_from_registry( array $component ) {
 
 	// Set the schema.
 	if ( ! empty( $registered['config'] ?? [] ) ) {
-		$component['schema'] = $registered['config'];
+		$component['config_schema'] = $registered['config'];
 	}
 
 	// Set the theme options.

--- a/tests/component-data/schema.json
+++ b/tests/component-data/schema.json
@@ -5,7 +5,7 @@
 			"example"
 		]
 	},
-	"schema": {
+	"config_schema": {
 		"wp_query": {
 			"hidden": true
 		}

--- a/tests/component-data/schema.json
+++ b/tests/component-data/schema.json
@@ -1,13 +1,14 @@
 {
 	"name": "irving/schema",
 	"config": {
-		"wp_query": [
-			"example"
-		]
+		"wp_query": {
+			"foo": "bar"
+		}
 	},
 	"config_schema": {
 		"wp_query": {
-			"hidden": true
+			"hidden": true,
+			"type": "object"
 		}
 	}
 }

--- a/tests/component-data/schema.json
+++ b/tests/component-data/schema.json
@@ -1,0 +1,13 @@
+{
+	"name": "irving/schema",
+	"config": {
+		"wp_query": [
+			"example"
+		]
+	},
+	"schema": {
+		"wp_query": {
+			"hidden": true
+		}
+	}
+}

--- a/tests/test-component.php
+++ b/tests/test-component.php
@@ -262,7 +262,7 @@ class Component_Tests extends WP_UnitTestCase {
 
 		$schema_example = $this->get_component( 'schema' );
 
-		$schema_example->set_schema( $new_schmea );
+		$schema_example->set_schema( $new_schema );
 
 		$this->assertEquals( $expects, $schema_example->get_schema(), 'Schema did not match what was expected.' );
 	}

--- a/tests/test-component.php
+++ b/tests/test-component.php
@@ -236,7 +236,7 @@ class Component_Tests extends WP_UnitTestCase {
 			'wp_query' => [
 				'default' => null,
 				'hidden'  => true,
-				'type'    => 'null',
+				'type'    => 'object',
 			],
 		];
 

--- a/tests/test-component.php
+++ b/tests/test-component.php
@@ -226,6 +226,48 @@ class Component_Tests extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests for the `get_schemaa()` method.
+	 */
+	public function test_get_schema() {
+
+		$schema_example = $this->get_component( 'schema' );
+
+		$expects = [
+			'wp_query' => [
+				'default' => null,
+				'hidden'  => true,
+				'type'    => 'null',
+			],
+		];
+
+		$this->assertEquals( $expects, $schema_example->get_schema(), 'Schema did not match what was expected.' );
+	}
+
+	/**
+	 * Tests for the `set_schemaa()` method.
+	 */
+	public function test_set_schema() {
+
+		$new_schmea = [
+			'post' => [],
+		];
+
+		$expects = [
+			'post' => [
+				'default' => null,
+				'hidden'  => false,
+				'type'    => 'null',
+			],
+		];
+
+		$schema_example = $this->get_component( 'schema' );
+
+		$schema_example->set_schema( $new_schmea );
+
+		$this->assertEquals( $expects, $schema_example->get_schema(), 'Schema did not match what was expected.' );
+	}
+
+	/**
 	 * Tests for the `get_children()` method.
 	 */
 	public function test_get_children() {
@@ -778,6 +820,20 @@ class Component_Tests extends WP_UnitTestCase {
 						'themeOptions' => [
 							'primary',
 							'secondary',
+						],
+					],
+					'children' => [],
+				],
+			],
+			[
+				'schema',
+				[
+					'name'     => 'irving/schema',
+					'config'   => (object) [
+						'wpQuery'      => null,
+						'themeName'    => 'default',
+						'themeOptions' => [
+							'default',
 						],
 					],
 					'children' => [],

--- a/tests/test-component.php
+++ b/tests/test-component.php
@@ -226,9 +226,9 @@ class Component_Tests extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests for the `get_schemaa()` method.
+	 * Tests for the `get_config_schema()` method.
 	 */
-	public function test_get_schema() {
+	public function test_get_config_schema() {
 
 		$schema_example = $this->get_component( 'schema' );
 
@@ -240,13 +240,13 @@ class Component_Tests extends WP_UnitTestCase {
 			],
 		];
 
-		$this->assertEquals( $expects, $schema_example->get_schema(), 'Schema did not match what was expected.' );
+		$this->assertEquals( $expects, $schema_example->get_config_schema(), 'Config schema did not match what was expected.' );
 	}
 
 	/**
-	 * Tests for the `set_schemaa()` method.
+	 * Tests for the `set_config_schema()` method.
 	 */
-	public function test_set_schema() {
+	public function test_set_config_schema() {
 
 		$new_schema = [
 			'post' => [],
@@ -262,9 +262,9 @@ class Component_Tests extends WP_UnitTestCase {
 
 		$schema_example = $this->get_component( 'schema' );
 
-		$schema_example->set_schema( $new_schema );
+		$schema_example->set_config_schema( $new_schema );
 
-		$this->assertEquals( $expects, $schema_example->get_schema(), 'Schema did not match what was expected.' );
+		$this->assertEquals( $expects, $schema_example->get_config_schema(), 'Schema did not match what was expected.' );
 	}
 
 	/**

--- a/tests/test-component.php
+++ b/tests/test-component.php
@@ -841,4 +841,116 @@ class Component_Tests extends WP_UnitTestCase {
 			],
 		];
 	}
+
+	/**
+	 * Tests for the component filter in the `jsonSerialize()` method.
+	 */
+	public function test_json_serialize_component_filter() {
+
+		$component = new Component( 'irving/text' );
+
+		add_filter( 'wp_irving_serialize_component', [ $this, 'wp_irving_serialize_component_action' ] );
+
+		$this->assertEquals(
+			[
+				'name'     => 'irving/text',
+				'config'   => (object) [
+					'test'         => true,
+					'themeName'    => 'default',
+					'themeOptions' => [
+						'default',
+					],
+				],
+				'children' => [],
+			],
+			$component->jsonSerialize(),
+			'Component serialization filter did not modify data correctly.'
+		);
+
+		remove_filter( 'wp_irving_serialize_component', [ $this, 'wp_irving_serialize_component_action' ] );
+
+		// Reset to test again.
+		$component = new Component( 'irving/text' );
+
+		$this->assertEquals(
+			[
+				'name'     => 'irving/text',
+				'config'   => (object) [
+					'themeName'    => 'default',
+					'themeOptions' => [
+						'default',
+					],
+				],
+				'children' => [],
+			],
+			$component->jsonSerialize(),
+			'Component serialization filter was not removed correctly.'
+		);
+	}
+
+	/**
+	 * Modify the config value of a component using a filter.
+	 *
+	 * @param Component $component Component instance.
+	 * @return Component
+	 */
+	public function wp_irving_serialize_component_action( Component $component ): Component {
+		return $component->set_config( 'test', true );
+	}
+	/**
+	 * Tests for the component (array) filter in the `jsonSerialize()` method.
+	 */
+	public function test_json_serialize_component_array_filter() {
+
+		$component = new Component( 'irving/text' );
+
+		add_filter( 'wp_irving_serialize_component_array', [ $this, 'wp_irving_serialize_component_array_action' ] );
+
+		$this->assertEquals(
+			[
+				'name'     => 'irving/text',
+				'config'   => (object) [
+					'test'         => true,
+					'themeName'    => 'default',
+					'themeOptions' => [
+						'default',
+					],
+				],
+				'children' => [],
+			],
+			$component->jsonSerialize(),
+			'Component serialization filter did not modify data correctly.'
+		);
+
+		remove_filter( 'wp_irving_serialize_component_array', [ $this, 'wp_irving_serialize_component_array_action' ] );
+
+		// Reset to test again.
+		$component = new Component( 'irving/text' );
+
+		$this->assertEquals(
+			[
+				'name'     => 'irving/text',
+				'config'   => (object) [
+					'themeName'    => 'default',
+					'themeOptions' => [
+						'default',
+					],
+				],
+				'children' => [],
+			],
+			$component->jsonSerialize(),
+			'Component serialization filter was not removed correctly.'
+		);
+	}
+
+	/**
+	 * Modify the config value of a component (as an array) using a filter.
+	 *
+	 * @param array $component Component (as an array).
+	 * @return array
+	 */
+	public function wp_irving_serialize_component_array_action( array $component ): array {
+		$component['config']->test = true;
+		return $component;
+	}
 }

--- a/tests/test-templates.php
+++ b/tests/test-templates.php
@@ -302,38 +302,4 @@ class Test_Templates extends WP_UnitTestCase {
 
 		$this->assertEquals( $expected, $hydrated, 'Template partial not hydrated correctly.' );
 	}
-
-	/**
-	 * Tests that context values are passed to non-registered components.
-	 */
-	public function test_templates_with_text_nodes() {
-
-		$template = [
-			[
-				'name'   => 'irving/text',
-				'config' => [
-					'content' => 'Foo Bar',
-				],
-			],
-			[ 'name' => 'example/component' ],
-		];
-
-		$expected = [
-			'Foo Bar',
-			[
-				'name'     => 'example/component',
-				'config'   => (object) [
-					'themeName'    => 'default',
-					'themeOptions' => [ 'default' ],
-				],
-				'children' => [],
-			],
-		];
-
-		$this->assertEquals(
-			$expected,
-			Templates\hydrate_components( $template ),
-			'`irving/text` component not turned into a string.'
-		);
-	}
 }


### PR DESCRIPTION
* Define a schema shape, and set it during the component registration process.
* Introduce filters for `jsonSerialize()`.
* If a config key has a `hidden` property set to true, set it to null upon serialization (so we're exposing sensitive data).
* Unit tests.