### PR TITLE
Feature/default contexts

### DIFF
--- a/inc/templates.php
+++ b/inc/templates.php
@@ -584,22 +584,12 @@ function get_template_context() {
 	if ( empty( $context ) ) {
 		$context = new WP_Irving\Context_Store();
 
-		// Set default context.
-		switch ( true ) {
-			case $wp_query->is_single():
-				$context->set( [ 'irving/post_id' => get_the_ID() ] );
-				break;
-
-			case $wp_query->is_archive():
-				$context->set(
-					[
-						'irving/archive_title'  => get_the_archive_title(),
-						'irving/queried_object' => get_queried_object(),
-						'irving/term_id'        => get_queried_object_id(),
-					]
-				);
-				break;
-		}
+		$context->set(
+			[
+				'irving/post_id'  => get_the_ID(),
+				'irving/wp_query' => $wp_query,
+			]
+		);
 	}
 
 	return $context;

--- a/inc/templates.php
+++ b/inc/templates.php
@@ -575,13 +575,28 @@ function hydrate_template_parts( $component ) {
  * @return WP_Irving\Context_Store The context store object.
  */
 function get_template_context() {
+	global $wp_query;
 	static $context;
 
 	if ( empty( $context ) ) {
 		$context = new WP_Irving\Context_Store();
 
 		// Set default context.
-		$context->set( [ 'irving/post' => get_the_ID() ] );
+		switch ( true ) {
+			case $wp_query->is_single():
+				$context->set( [ 'irving/post_id' => get_the_ID() ] );
+				break;
+
+			case $wp_query->is_archive():
+				$context->set(
+					[
+						'irving/archive_title'  => get_the_archive_title(),
+						'irving/queried_object' => get_queried_object(),
+						'irving/term_id'        => get_queried_object_id(),
+					]
+				);
+				break;
+		}
 	}
 
 	return $context;

--- a/tests/test-templates.php
+++ b/tests/test-templates.php
@@ -95,7 +95,8 @@ class Test_Templates extends WP_UnitTestCase {
 		$context = Templates\get_template_context();
 
 		// Test initial context.
-		$this->assertEquals( $post->ID, $context->get( 'irving/post' ), 'Default post context not set.' );
+		$this->assertEquals( $post->ID, $context->get( 'irving/post_id' ), 'Default post ID context not set.' );
+		$this->assertEquals( new \WP_Query( [] ), $context->get( 'irving/wp_query' ), 'Default wp query context not set.' );
 	}
 
 	/**


### PR DESCRIPTION
Tweak the default context for templates to have the post_id and wp_query.