### PR TITLE
Update loop to continue instead of break.

### DIFF
--- a/inc/templates.php
+++ b/inc/templates.php
@@ -388,7 +388,7 @@ function hydrate_components( array $components ) {
 
 			// A little cleanup.
 			unset( $template_data );
-			break;
+			continue;
 		}
 
 		// Set up config from context.


### PR DESCRIPTION
Currently, if you include a component after a template part, the loop dies instead of continuing, preventing following siblings to be rendered.