### PR TITLE
Support child theme functionality with templates

### DIFF
--- a/inc/templates/namespace.php
+++ b/inc/templates/namespace.php
@@ -286,7 +286,7 @@ function locate_template( array $templates ): string {
 			break;
 		}
 
-		// If stylehseet and template directory don't match, look in the parent directory.
+		// Support child themes if the template path is in the theme.
 		if (
 			is_child_theme()
 			&& 0 === strpos( $template_path, get_stylesheet_directory() )
@@ -349,6 +349,24 @@ function locate_template_part( string $template ): string {
 		// If the file is located, break out of filetype loop.
 		if ( file_exists( $path ) ) {
 			return $path;
+		}
+	}
+
+	// Support child themes if the template part path is in the theme.
+	if (
+		is_child_theme()
+		&& 0 === strpos( $template_part_path, get_stylesheet_directory() )
+	) {
+		$child_template_part_path = str_replace( get_stylesheet_directory(), get_template_directory(), $template_part_path );
+
+		foreach ( $filetypes as $type ) {
+			// Ensure filtered template paths are slashed.
+			$path = trailingslashit( $child_template_part_path ) . $template_base . '.' . $type;
+
+			// If the file is located, break out of filetype loop.
+			if ( file_exists( $path ) ) {
+				return $path;
+			}
 		}
 	}
 

--- a/inc/templates/namespace.php
+++ b/inc/templates/namespace.php
@@ -166,12 +166,12 @@ function prepare_data_from_template( string $template_path ): array {
 			}
 
 			// Hydrate page and default data separately.
-			if ( isset( $data['page'] ) || isset( $data['default'] ) ) {
+			if ( isset( $data['page'] ) || isset( $data['defaults'] ) ) {
 				if ( isset( $data['page'] ) ) {
 					$data['page'] = hydrate_template( $data['page'] );
 				}
-				if ( isset( $data['default'] ) ) {
-					$data['default'] = hydrate_template( $data['default'] );
+				if ( isset( $data['defaults'] ) ) {
+					$data['defaults'] = hydrate_template( $data['defaults'] );
 				}
 			} else {
 				$data = hydrate_template( $data );
@@ -246,6 +246,7 @@ function filter_template_loader() {
  * @return string The path to the found template.
  */
 function locate_template( array $templates ): string {
+
 	$template_path = get_stylesheet_directory() . '/templates/';
 
 	/**
@@ -273,6 +274,8 @@ function locate_template( array $templates ): string {
 			// Ensure filtered template paths are slashed.
 			$path = trailingslashit( $template_path ) . $template_base . '.' . $type;
 
+			// echo $path . "\n";
+
 			// If the file is located, break out of filetype loop.
 			if ( file_exists( $path ) ) {
 				$located = $path;
@@ -283,6 +286,32 @@ function locate_template( array $templates ): string {
 		// Break out of template type loop.
 		if ( $located ) {
 			break;
+		}
+
+		// If stylehseet and template directory don't match, look in the parent directory.
+		if (
+			get_template_directory() !== get_stylesheet_directory()
+			&& 0 === strpos( $template_path, get_stylesheet_directory() )
+		) {
+			$child_template_path = str_replace( get_stylesheet_directory(), get_template_directory(), $template_path );
+
+			foreach ( $filetypes as $type ) {
+				// Ensure filtered template paths are slashed.
+				$path = trailingslashit( $child_template_path ) . $template_base . '.' . $type;
+
+				// echo $path . "\n";
+
+				// If the file is located, break out of filetype loop.
+				if ( file_exists( $path ) ) {
+					$located = $path;
+					break;
+				}
+			}
+
+			// Break out of template type loop.
+			if ( $located ) {
+				break;
+			}
 		}
 	}
 

--- a/inc/templates/namespace.php
+++ b/inc/templates/namespace.php
@@ -288,7 +288,7 @@ function locate_template( array $templates ): string {
 
 		// If stylehseet and template directory don't match, look in the parent directory.
 		if (
-			get_template_directory() !== get_stylesheet_directory()
+			is_child_theme()
 			&& 0 === strpos( $template_path, get_stylesheet_directory() )
 		) {
 			$child_template_path = str_replace( get_stylesheet_directory(), get_template_directory(), $template_path );

--- a/inc/templates/namespace.php
+++ b/inc/templates/namespace.php
@@ -274,8 +274,6 @@ function locate_template( array $templates ): string {
 			// Ensure filtered template paths are slashed.
 			$path = trailingslashit( $template_path ) . $template_base . '.' . $type;
 
-			// echo $path . "\n";
-
 			// If the file is located, break out of filetype loop.
 			if ( file_exists( $path ) ) {
 				$located = $path;
@@ -298,8 +296,6 @@ function locate_template( array $templates ): string {
 			foreach ( $filetypes as $type ) {
 				// Ensure filtered template paths are slashed.
 				$path = trailingslashit( $child_template_path ) . $template_base . '.' . $type;
-
-				// echo $path . "\n";
 
 				// If the file is located, break out of filetype loop.
 				if ( file_exists( $path ) ) {

--- a/inc/templates/namespace.php
+++ b/inc/templates/namespace.php
@@ -246,7 +246,6 @@ function filter_template_loader() {
  * @return string The path to the found template.
  */
 function locate_template( array $templates ): string {
-
 	$template_path = get_stylesheet_directory() . '/templates/';
 
 	/**

--- a/inc/templates/site-theme.php
+++ b/inc/templates/site-theme.php
@@ -94,7 +94,11 @@ function get_site_theme_from_json_files() {
 
 	$theme = [];
 
-	$path = apply_filters( 'wp_irving_site_theme_json_directory_path', get_template_directory() . '/styles/' );
+	$path = apply_filters( 'wp_irving_site_theme_json_directory_path', get_stylesheet_directory() . '/styles/' );
+
+	if ( ! is_dir( $path ) ) {
+		$path = apply_filters( 'wp_irving_site_theme_json_directory_path', get_template_directory() . '/styles/' );
+	}
 
 	if ( ! is_dir( $path ) ) {
 		return [];

--- a/tests/templates/templates/test-simple.json
+++ b/tests/templates/templates/test-simple.json
@@ -1,5 +1,5 @@
 {
-  "default": [
+  "defaults": [
     { "name": "test/component" }
   ],
   "page": [

--- a/tests/templates/test-templates.php
+++ b/tests/templates/test-templates.php
@@ -201,7 +201,7 @@ class Test_Templates extends WP_UnitTestCase {
 			'defaults' => [
 				new Component( 'test/component' ),
 			],
-			'page'    => [
+			'page'     => [
 				new Component( 'test/component' ),
 			],
 		];

--- a/tests/templates/test-templates.php
+++ b/tests/templates/test-templates.php
@@ -198,7 +198,7 @@ class Test_Templates extends WP_UnitTestCase {
 	 */
 	public function test_prepare_data_from_template() {
 		$expected = [
-			'default' => [
+			'defaults' => [
 				new Component( 'test/component' ),
 			],
 			'page'    => [


### PR DESCRIPTION
* Fixes a bug with `default` vs. `defaults`.
* Support using the templates and template parts in a child/parent theme context.
* If a child theme hasn't defined a site theme in /styles/, use the parent directory.

Note: I have no idea how to test this functionality since it's all dependent on child/parent themes. Suggestions welcome.