### PR TITLE
IRV-554: Update Post Permalink Component

### DIFF
--- a/inc/components/components/post-permalink/component.json
+++ b/inc/components/components/post-permalink/component.json
@@ -2,6 +2,24 @@
   "name": "irving/post-permalink",
   "_alias": "irving/link",
   "description": "Get the post permalink.",
+  "config": {
+    "href": {
+      "default": "",
+      "type": "string"
+    },
+    "rel": {
+      "default": "",
+      "type": "string"
+    },
+    "style": {
+      "default": [],
+      "type": "array"
+    },
+    "target": {
+      "default": "",
+      "type": "string"
+    }
+  },
   "use_context": {
     "irving/post_id": "post_id"
   }

--- a/inc/components/components/post-permalink/component.php
+++ b/inc/components/components/post-permalink/component.php
@@ -9,23 +9,35 @@
 
 namespace WP_Irving\Components;
 
+use WP_Post;
+
 /**
  * Register the component and callback.
  */
 register_component_from_config(
 	__DIR__ . '/component',
 	[
-		'callback' => function( Component $component ): Component {
+		'config_callback' => function ( array $config ): array {
+			$post_id = $config['post_id'];
 
-			// Get the post ID from a context provider.
-			$post_id = $component->get_config( 'post_id' );
-
-			$post = get_post( $post_id );
-			if ( ! $post instanceof \WP_Post ) {
-				return $component;
+			// Bail early if we have no post ID.
+			if ( ! $post_id ) {
+				return $config;
 			}
 
-			return $component->set_config( 'href', get_permalink( $post_id ) );
+			$permalink = get_the_permalink( $post_id );
+
+			// Bail if we have no permalink.
+			if ( is_wp_error( $permalink ) ) {
+				return $config;
+			}
+
+			return array_merge(
+				$config,
+				[
+					'href' => $permalink,
+				]
+			);
 		},
 	]
 );

--- a/tests/components/test-components.php
+++ b/tests/components/test-components.php
@@ -573,6 +573,33 @@ class Test_Components extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test irving/post-permalink component.
+	 *
+	 * @group core-components
+	 */
+	public function test_component_post_permalink() {
+		$this->go_to( '?p=' . $this->get_post_id() );
+
+		$expected = $this->get_expected_component(
+			'irving/post-permalink',
+			[
+				'_alias' => 'irving/link',
+				'config' => [
+					'href'   => get_the_permalink( $this->get_post_id() ),
+					'rel'    => '',
+					'style'  => [],
+					'target' => '',
+					'postId' => $this->get_post_id(),
+				],
+			]
+		);
+
+		$component = new Component( 'irving/post-permalink' );
+
+		$this->assertComponentEquals( $expected, $component );
+	}
+
+	/**
 	 * Helper for creating expected output for components.
 	 *
 	 * Returns default values so you don't have to write as much boilerplate.


### PR DESCRIPTION
This updates the post-list component to use the new `config_callback` pattern and updates the component.json file to match the shape of the `irving/link` component to ensure that defaults are automatically set.

Blocked by #189.