### PR TITLE
IRV-554 Update post provider

### DIFF
--- a/inc/components/namespace.php
+++ b/inc/components/namespace.php
@@ -88,6 +88,16 @@ function register_component( string $name, array $args = [] ): bool {
 }
 
 /**
+ * Unregister a component.
+ *
+ * @param string $name Component name.
+ * @return bool Returns true if successful.
+ */
+function unregister_component( string $name ): bool {
+	return get_registry()->unregister_component( $name );
+}
+
+/**
  * Register a component using a json config.
  *
  * @param string $config_path JSON config file.

--- a/tests/components/test-components.php
+++ b/tests/components/test-components.php
@@ -600,6 +600,58 @@ class Test_Components extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test irving/post-provider component.
+	 *
+	 * @group core-components
+	 */
+	public function test_component_post_provider() {
+		// Register a component that receives the post_id context.
+		register_component(
+			'example/use-context',
+			[
+				'use_context' => [
+					'irving/post_id' => 'post_id',
+				],
+			]
+		);
+
+		$expected = $this->get_expected_component(
+			'irving/post-provider',
+			[
+				'_alias'   => 'irving/fragment',
+				'config'   => [
+					'postId' => $this->get_post_id(),
+				],
+				'children' => [
+					$this->get_expected_component(
+						'example/use-context',
+						[
+							'config' => [ 'postId' => $this->get_post_id() ],
+						]
+					),
+				],
+			]
+		);
+
+		$component = new Component(
+			'irving/post-provider',
+			[
+				'config'   => [
+					'post_id' => $this->get_post_id(),
+				],
+				'children' => [
+					[ 'name' => 'example/use-context' ],
+				],
+			]
+		);
+
+		// Cleanup.
+		unregister_component( 'example/use-context' );
+
+		$this->assertComponentEquals( $expected, $component );
+	}
+
+	/**
 	 * Helper for creating expected output for components.
 	 *
 	 * Returns default values so you don't have to write as much boilerplate.


### PR DESCRIPTION
This adds a unit test for the `irving/post-provider` component.

Adds:

* WP_Irving\Components\unregister_component() – Helper for unregistering a component.