### PR TITLE
Update Travis tests to run against PHP versions 7.3/7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,15 +19,12 @@ cache:
 
 matrix:
   include:
-    - php: 7.2
+    - php: 7.3
       env: WP_VERSION=latest
-    - php: 7.2
+    - php: 7.3
       env: WP_TRAVISCI=phpcs
-    - php: 7.1
+    - php: 7.4
       env: WP_VERSION=trunk
-    # This build results in an error, not sure how to address yet.
-    # - php: 7.0
-    #   env: WP_VERSION=4.5
 
 before_script:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"


### PR DESCRIPTION
Previously these tests were running against PHP version 7.2 when running
PHPUnit against the latest version of WP and for PHPCS runs and PHP 7.1
when running PHPUnit against trunk. This change makes it so the latest
version of WP and PHPCS runs PHP version 7.3, which is our most common
currently in production and uses PHP verison 7.4 when runing tests against
trunk, since both are meant to help catch future breakage.