### PR TITLE
Allow short ternary operator

### DIFF
--- a/inc/components/class-component.php
+++ b/inc/components/class-component.php
@@ -151,7 +151,6 @@ class Component implements JsonSerializable {
 			'visibility_callback' => null, // @todo implement.
 		];
 
-		// phpcs:ignore WordPress.PHP.DisallowShortTernary
 		$schema = get_registry()->get_registered_component( $this->name ) ?: [];
 
 		$schema = wp_parse_args(

--- a/inc/components/components/post-excerpt/component.php
+++ b/inc/components/components/post-excerpt/component.php
@@ -19,7 +19,6 @@ register_component_from_config(
 	__DIR__ . '/component',
 	[
 		'config_callback' => function( array $config ): array {
-			// phpcs:ignore WordPress.PHP.DisallowShortTernary
 			$post_id = $config['post_id'] ?: 0;
 
 			if ( ! $post_id ) {

--- a/inc/components/components/post-featured-image/component.php
+++ b/inc/components/components/post-featured-image/component.php
@@ -20,7 +20,6 @@ register_component_from_config(
 	__DIR__ . '/component',
 	[
 		'config_callback' => function( array $config ): array {
-			// phpcs:ignore WordPress.PHP.DisallowShortTernary
 			$post_id = $config['post_id'] ?: 0;
 
 			if ( ! $post_id ) {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -6,6 +6,12 @@
     <rule ref="vendor/alley/alley-coding-standards" />
 
     <!-- Project customizations go here -->
+
+	<rule ref="WordPress">
+		<!-- Allow short ternary expressions -->
+		<exclude name="WordPress.PHP.DisallowShortTernary" />
+	</rule>
+
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<!--


### PR DESCRIPTION
This excludes the `WordPress.PHP.DisallowShortTernary` rule from the WP coding standards
and removes places where we've explicitly ignored this rule in our code.