### PR TITLE
IRV-554: Update post timestamp component

### DIFF
--- a/inc/components/components/post-timestamp/component.json
+++ b/inc/components/components/post-timestamp/component.json
@@ -3,24 +3,36 @@
   "_alias": "irving/text",
   "description": "Get the post's timestamp(s).",
   "config": {
+    "content": {
+      "default": "",
+      "type": "string"
+    },
     "content_format": {
       "default": "%1$s",
-      "description": "The format string used by `sprintf()`. Used to build the `content` output. See callback for all available replacements.",
+      "type": "string",
+      "hidden": true
+    },
+    "modified_date": {
+      "default": "",
       "type": "string"
     },
     "modified_date_format": {
       "default": "",
-      "description": "Format for the modified timestamp. Empty string defaults to WordPress' option.",
-      "type": "string"
+      "type": "string",
+      "hidden": true
     },
     "post_id": {
       "default": 0,
-      "type": "integer"
+      "type": "int"
     },
-    "published_date_format": {
+    "post_date": {
       "default": "",
-      "description": "Format for the timestamp. Empty string defaults to WordPress' option.",
       "type": "string"
+    },
+    "post_date_format": {
+      "default": "",
+      "type": "string",
+      "hidden": true
     }
   },
   "use_context": {

--- a/inc/components/components/post-timestamp/component.php
+++ b/inc/components/components/post-timestamp/component.php
@@ -15,28 +15,36 @@ namespace WP_Irving\Components;
 register_component_from_config(
 	__DIR__ . '/component',
 	[
-		'callback' => function( Component $component ): Component {
+		'config_callback' => function( array $config ): array {
 
-			// Get the post ID from a context provider.
-			$post_id = $component->get_config( 'post_id' );
+			$post_id = $config['post_id'];
 
-			$post = get_post( $post_id );
-			if ( ! $post instanceof \WP_Post ) {
-				return $component;
+			// Bail if there is no post ID.
+			if ( ! $post_id ) {
+				return $config;
 			}
 
-			return $component->set_config(
-				'content',
-				sprintf(
-					/**
-					 * Translators:
-					 * %1$s - Published timestamp.
-					 * %2$s - Modified timestamp.
-					 */
-					$component->get_config( 'content_format' ),
-					get_the_date( $component->get_config( 'published_date_format' ), $post_id ),
-					get_the_modified_date( $component->get_config( 'modified_date_format' ), $post_id )
-				)
+			$post_date     = get_the_date( $config['post_date_format'], $post_id );
+			$modified_date = get_the_modified_date( $config['modified_date_format'], $post_id );
+
+			$content = sprintf(
+				/**
+				 * Translators:
+				 * %1$s - Published timestamp.
+				 * %2$s - Modified timestamp.
+				 */
+				$config['content_format'],
+				esc_html( $post_date ),
+				esc_html( $modified_date ),
+			);
+
+			return array_merge(
+				$config,
+				[
+					'content'       => $content,
+					'modified_date' => $modified_date,
+					'post_date'     => $post_date,
+				]
 			);
 		},
 	]

--- a/tests/components/test-components.php
+++ b/tests/components/test-components.php
@@ -669,6 +669,73 @@ class Test_Components extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test irving/post-timestamp component.
+	 *
+	 * @group core-components
+	 */
+	public function test_component_post_timestamp() {
+		$this->go_to( '?p=' . $this->get_post_id() );
+
+		$modified_date = get_the_modified_date( '', $this->get_post_id() );
+		$post_date     = get_the_date( '', $this->get_post_id() );
+
+		$expected = $this->get_expected_component(
+			'irving/post-timestamp',
+			[
+				'_alias' => 'irving/text',
+				'config' => [
+					'content'      => $post_date,
+					'modifiedDate' => $modified_date,
+					'postId'       => $this->get_post_id(),
+					'postDate'     => $post_date,
+				],
+			]
+		);
+
+		$component = new Component( 'irving/post-timestamp' );
+
+		$this->assertComponentEquals( $expected, $component );
+	}
+
+	/**
+	 * Test irving/post-timestamp component with non-default formats.
+	 *
+	 * @group core-components
+	 */
+	public function test_component_post_timestamp_with_formats() {
+		$this->go_to( '?p=' . $this->get_post_id() );
+
+		$modified_date = get_the_modified_date( 'l F j, Y', $this->get_post_id() );
+		$post_date     = get_the_date( 'Ymd', $this->get_post_id() );
+
+		$expected = $this->get_expected_component(
+			'irving/post-timestamp',
+			[
+				'_alias' => 'irving/text',
+				'config' => [
+					'content'      => sprintf( 'Posted: %1$s. Modified: %2$s', $post_date, $modified_date ),
+					'modifiedDate' => $modified_date,
+					'postId'       => $this->get_post_id(),
+					'postDate'     => $post_date,
+				],
+			]
+		);
+
+		$component = new Component(
+			'irving/post-timestamp',
+			[
+				'config' => [
+					'content_format'       => 'Posted: %1$s. Modified: %2$s',
+					'modified_date_format' => 'l F j, Y',
+					'post_date_format'     => 'Ymd',
+				],
+			]
+		);
+
+		$this->assertComponentEquals( $expected, $component );
+	}
+
+	/**
 	 * Helper for creating expected output for components.
 	 *
 	 * Returns default values so you don't have to write as much boilerplate.


### PR DESCRIPTION
Updates the component.php to use the `config_callback()` pattern and
adds unit tests for both default and formatted variations.