### PR TITLE
IRV-554: Update post-title component

### DIFF
--- a/inc/components/components/post-title/component.php
+++ b/inc/components/components/post-title/component.php
@@ -15,12 +15,14 @@ namespace WP_Irving\Components;
 register_component_from_config(
 	__DIR__ . '/component',
 	[
-		'callback' => function( Component $component ): Component {
+		'config_callback' => function ( array $config ): array {
 
-			// Get the post ID from a context provider.
-			$post_id = $component->get_config( 'post_id' );
+			// Post ID is set via context and should always have a value.
+			$title = get_the_title( $config['post_id'] );
 
-			return $component->set_config( 'content', html_entity_decode( get_the_title( $post_id ) ) );
+			$config['content'] = html_entity_decode( $title, ENT_QUOTES, get_bloginfo( 'charset' ) );
+
+			return $config;
 		},
 	]
 );

--- a/tests/components/test-components.php
+++ b/tests/components/test-components.php
@@ -149,6 +149,7 @@ class Test_Components extends WP_UnitTestCase {
 		self::$post_id = $factory->post->create(
 			[
 				'post_author'   => self::$author_id,
+				'post_title'    => "It's like this & that.", // Tests HTML entities.
 				'_thumbnail_id' => self::$attachment_id,
 			]
 		);
@@ -731,6 +732,30 @@ class Test_Components extends WP_UnitTestCase {
 				],
 			]
 		);
+
+		$this->assertComponentEquals( $expected, $component );
+	}
+
+	/**
+	 * Test irving/post-title component.
+	 *
+	 * @group core-components
+	 */
+	public function test_component_post_title() {
+		$this->go_to( '?p=' . $this->get_post_id() );
+
+		$expected = $this->get_expected_component(
+			'irving/post-title',
+			[
+				'_alias' => 'irving/text',
+				'config' => [
+					'content' => 'It’s like this & that.', // Texturized.
+					'postId'  => $this->get_post_id(),
+				],
+			]
+		);
+
+		$component = new Component( 'irving/post-title' );
 
 		$this->assertComponentEquals( $expected, $component );
 	}


### PR DESCRIPTION
This updates the component.php to use the new `config_callback` pattern
and adds unit tests.