### PR TITLE
IRV-384: Add a "clear the cache" button to the Irving admin bar

### DIFF
--- a/inc/endpoints/class-cache-endpoint.php
+++ b/inc/endpoints/class-cache-endpoint.php
@@ -13,15 +13,15 @@ namespace WP_Irving\REST_API;
 class Cache_Endpoint extends Endpoint {
 	/**
 	 * Attach to required hooks for endpoint.
-	*/
+	 */
 	public function __construct() {
 		parent::__construct();
 
 		// Register the route.
 		add_action( 'rest_api_init', [ $this, 'register_rest_routes' ] );
 		// Cache purge actions.
-		add_action( 'wp_irving_site_cache_purge', [ $this, 'purge_site_cache' ] );
-		add_action( 'wp_irving_page_cache_purge', [ $this, 'purge_page_cache' ] );
+		add_action( 'irving_site_cache_purge', [ $this, 'purge_site_cache' ] );
+		add_action( 'irving_page_cache_purge', [ $this, 'purge_page_cache' ] );
 	}
 
 	/**
@@ -50,18 +50,18 @@ class Cache_Endpoint extends Endpoint {
 		$action = $request_params['action'];
 
 		// Ensure the action exists prior to firing.
-		if ( !empty( $action ) ) {
-			if ( $action === 'irving_site_cache_purge' ) {
-				do_action( 'wp_' . $action );
+		if ( ! empty( $action ) ) {
+			if ( 'irving_site_cache_purge' === $action ) {
+				do_action( $action );
 			}
 
-			if ( $action === 'irving_page_cache_purge' ) {
+			if ( 'irving_page_cache_purge' === $action ) {
 				// Get the route.
 				$route = $request_params['route'];
 				// Ensure the requested route is not empty prior
 				// to firing the action.
-				if ( !empty( $route ) ) {
-					do_action( 'wp_' . $action, $route );
+				if ( ! empty( $route ) ) {
+					do_action( $action, $route );
 				}
 			}
 		}
@@ -80,7 +80,7 @@ class Cache_Endpoint extends Endpoint {
 
 	/**
 	 * Purge the cache for a specific route/page.
-	 *
+	 * d
 	 * @param string $route The target route to purge from the cache.
 	 */
 	public function purge_page_cache( $route ) {
@@ -91,7 +91,7 @@ class Cache_Endpoint extends Endpoint {
 		}
 		// Check for Pantheon environments.
 		if ( function_exists( 'patheon_wp_clear_edge_paths' ) ) {
-			pantheon_wp_clear_edge_paths( [$route] );
+			pantheon_wp_clear_edge_paths( [ $route ] );
 		}
 	}
 }

--- a/inc/endpoints/class-cache-endpoint.php
+++ b/inc/endpoints/class-cache-endpoint.php
@@ -27,8 +27,7 @@ class Cache_Endpoint extends Endpoint {
             self::get_namespace(),
             '/purge-cache',
             [
-                // 'methods'  => \WP_REST_Server::CREATABLE,
-                'methods'  => \WP_REST_Server::READABLE,
+                'methods'  => \WP_REST_Server::CREATABLE,
                 'callback' => [ $this, 'get_route_response' ],
             ]
         );
@@ -42,7 +41,6 @@ class Cache_Endpoint extends Endpoint {
 	 * @return array
 	 */
     public function get_route_response( $request ) {
-        // phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited
-        global $wp;
+        return $request;
     }
 }

--- a/inc/endpoints/class-cache-endpoint.php
+++ b/inc/endpoints/class-cache-endpoint.php
@@ -52,7 +52,7 @@ class Cache_Endpoint extends Endpoint {
 		// Ensure the action exists prior to firing.
 		if ( ! empty( $action ) ) {
 			if ( 'irving_site_cache_purge' === $action ) {
-				do_action( 'wp_' . $action );
+				do_action( 'wp_irving_site_cache_purge' );
 			}
 
 			if ( 'irving_page_cache_purge' === $action ) {
@@ -61,7 +61,7 @@ class Cache_Endpoint extends Endpoint {
 				// Ensure the requested route is not empty prior
 				// to firing the action.
 				if ( ! empty( $route ) ) {
-					do_action( 'wp_' . $action, $route );
+					do_action( 'wp_irving_page_cache_purge', $route );
 				}
 			}
 		}

--- a/inc/endpoints/class-cache-endpoint.php
+++ b/inc/endpoints/class-cache-endpoint.php
@@ -4,89 +4,94 @@
  *
  * @package WP_Irving
  */
+
 namespace WP_Irving\REST_API;
 
 /**
  * Cache Endpoint.
  */
 class Cache_Endpoint extends Endpoint {
-    /**
-     * Attach to required hooks for endpoint.
-     */
-    public function __construct() {
-        parent::__construct();
+	/**
+	 * Attach to required hooks for endpoint.
+	*/
+	public function __construct() {
+		parent::__construct();
 
-        // Register the route.
-        add_action( 'rest_api_init', [ $this, 'register_rest_routes' ] );
-        // Cache purge actions.
-        add_action( 'wp_irving_site_cache_purge', [ $this, 'purge_site_cache' ] );
-        add_action( 'wp_irving_page_cache_purge', [ $this, 'purge_page_cache' ] );
-    }
+		// Register the route.
+		add_action( 'rest_api_init', [ $this, 'register_rest_routes' ] );
+		// Cache purge actions.
+		add_action( 'wp_irving_site_cache_purge', [ $this, 'purge_site_cache' ] );
+		add_action( 'wp_irving_page_cache_purge', [ $this, 'purge_page_cache' ] );
+	}
 
-    /**
-     * Register the REST API routes.
-     */
-    public function register_rest_routes() {
-        register_rest_route(
-            self::get_namespace(),
-            '/purge-cache',
-            [
-                'methods'  => \WP_REST_Server::CREATABLE,
-                'callback' => [ $this, 'get_route_response' ],
-            ]
-        );
-    }
+	/**
+	 * Register the REST API routes.
+	 */
+	public function register_rest_routes() {
+		register_rest_route(
+			self::get_namespace(),
+			'/purge-cache',
+			[
+				'methods'  => \WP_REST_Server::CREATABLE,
+				'callback' => [ $this, 'get_route_response' ],
+			]
+		);
+	}
 
 	/**
 	 * Callback for the route.
 	 *
 	 * @param  WP_REST_Request $request Request object.
 	 */
-    public function get_route_response( $request ) {
-        // Get the request body.
-        $request_params = $request->get_body_params();
-        // Get the requested action.
-        $action = $request_params['action'];
+	public function get_route_response( $request ) {
+		// Get the request body.
+		$request_params = $request->get_body_params();
+		// Get the requested action.
+		$action = $request_params['action'];
 
-        // Ensure the action exists prior to firing.
-        if ( !empty( $action ) ) {
-            if ( $action === 'irving_site_cache_purge' ) {
-                do_action( 'wp_' . $action );
-            }
+		// Ensure the action exists prior to firing.
+		if ( !empty( $action ) ) {
+			if ( $action === 'irving_site_cache_purge' ) {
+				do_action( 'wp_' . $action );
+			}
 
-            if ( $action === 'irving_page_cache_purge' ) {
-                // Get the route.
-                $route = $request_params['route'];
-                // Ensure the requested route is not empty prior
-                // to firing the action.
-                if ( !empty( $route ) ) {
-                    do_action( 'wp_' . $action, $route );
-                }
-            }
-        }
-    }
+			if ( $action === 'irving_page_cache_purge' ) {
+				// Get the route.
+				$route = $request_params['route'];
+				// Ensure the requested route is not empty prior
+				// to firing the action.
+				if ( !empty( $route ) ) {
+					do_action( 'wp_' . $action, $route );
+				}
+			}
+		}
+	}
 
-    /**
-     * Purge the site cache.
-     */
-    public function purge_site_cache() {
-        if ( function_exists( 'pantheon_wp_clear_edge_paths' ) ) {
-            \WP_Irving\Pantheon::pantheon_flush_site();
-        } else {
-            \WP_Irving\Cache::instance()->fire_wipe_request();
-        }
-    }
+	/**
+	 * Purge the site cache.
+	 */
+	public function purge_site_cache() {
+		if ( function_exists( 'pantheon_wp_clear_edge_paths' ) ) {
+			\WP_Irving\Pantheon::pantheon_flush_site();
+		} else {
+			\WP_Irving\Cache::instance()->fire_wipe_request();
+		}
+	}
 
-    /**
-     * Purge the cache for a specific route/page.
-     *
-     * @param string $route The target route to purge from the cache.
-     */
-    public function purge_page_cache( $route ) {
-        // Check to see if the action is being executed on a VIP Go enabled
-        // environment. If so, use VIP's purge function.
-        if ( function_exists( 'wpcom_vip_purge_edge_cache_for_url' ) ) {
-            wpcom_vip_purge_edge_cache_for_url( $route );
-        }
-    }
+	/**
+	 * Purge the cache for a specific route/page.
+	 *
+	 * @param string $route The target route to purge from the cache.
+	 */
+	public function purge_page_cache( $route ) {
+		// Check to see if the action is being executed on a VIP Go enabled
+		// environment. If so, use VIP's purge function.
+		if ( function_exists( 'wpcom_vip_purge_edge_cache_for_url' ) ) {
+			wpcom_vip_purge_edge_cache_for_url( $route );
+		}
+		// Check for Pantheon environments.
+		if ( function_exists( 'patheon_wp_clear_edge_paths' ) ) {
+			pantheon_wp_clear_edge_paths( [$route] );
+		}
+	}
 }

--- a/inc/endpoints/class-cache-endpoint.php
+++ b/inc/endpoints/class-cache-endpoint.php
@@ -20,8 +20,8 @@ class Cache_Endpoint extends Endpoint {
 		// Register the route.
 		add_action( 'rest_api_init', [ $this, 'register_rest_routes' ] );
 		// Cache purge actions.
-		add_action( 'irving_site_cache_purge', [ $this, 'purge_site_cache' ] );
-		add_action( 'irving_page_cache_purge', [ $this, 'purge_page_cache' ] );
+		add_action( 'wp_irving_site_cache_purge', [ $this, 'purge_site_cache' ] );
+		add_action( 'wp_irving_page_cache_purge', [ $this, 'purge_page_cache' ] );
 	}
 
 	/**
@@ -52,7 +52,7 @@ class Cache_Endpoint extends Endpoint {
 		// Ensure the action exists prior to firing.
 		if ( ! empty( $action ) ) {
 			if ( 'irving_site_cache_purge' === $action ) {
-				do_action( $action );
+				do_action( 'wp_' . $action );
 			}
 
 			if ( 'irving_page_cache_purge' === $action ) {
@@ -61,7 +61,7 @@ class Cache_Endpoint extends Endpoint {
 				// Ensure the requested route is not empty prior
 				// to firing the action.
 				if ( ! empty( $route ) ) {
-					do_action( $action, $route );
+					do_action( 'wp_' . $action, $route );
 				}
 			}
 		}
@@ -80,7 +80,7 @@ class Cache_Endpoint extends Endpoint {
 
 	/**
 	 * Purge the cache for a specific route/page.
-	 * d
+	 *
 	 * @param string $route The target route to purge from the cache.
 	 */
 	public function purge_page_cache( $route ) {

--- a/inc/endpoints/class-cache-endpoint.php
+++ b/inc/endpoints/class-cache-endpoint.php
@@ -16,7 +16,11 @@ class Cache_Endpoint extends Endpoint {
     public function __construct() {
         parent::__construct();
 
+        // Register the route.
         add_action( 'rest_api_init', [ $this, 'register_rest_routes' ] );
+        // Cache purge actions.
+        add_action( 'wp_irving_site_cache_purge', [ $this, 'purge_site_cache' ] );
+        add_action( 'wp_irving_page_cache_purge', [ $this, 'purge_page_cache' ] );
     }
 
     /**
@@ -37,10 +41,48 @@ class Cache_Endpoint extends Endpoint {
 	 * Callback for the route.
 	 *
 	 * @param  WP_REST_Request $request Request object.
-	 *
-	 * @return array
 	 */
     public function get_route_response( $request ) {
-        return $request;
+        // Get the request body.
+        $request_params = $request->get_body_params();
+        // Get the requested action.
+        $action = $request_params['action'];
+
+        // Ensure the action exists prior to firing.
+        if ( !empty( $action ) ) {
+            if ( $action === 'irving_site_cache_purge' ) {
+                do_action( 'wp_' . $action );
+            }
+
+            if ( $action === 'irving_page_cache_purge' ) {
+                // Get the route.
+                $route = request_params['route'];
+                // Ensure the requested route is not empty prior
+                // to firing the action.
+                if ( !empty( $route ) ) {
+                    do_action( 'wp_' . $action, $route );
+                }
+            }
+        }
+    }
+
+    /**
+     * Purge the site cache.
+     */
+    public function purge_site_cache() {
+        if ( function_exists( 'pantheon_wp_clear_edge_paths' ) ) {
+            \WP_Irving\Pantheon::pantheon_flush_site();
+        } else {
+            \WP_Irving\Cache::instance()->fire_wipe_request();
+        }
+    }
+
+    /**
+     * Purge the cache for a specific route/page.
+     *
+     * @param string $route The target route to purge from the cache.
+     */
+    public function purge_page_cache( $args ) {
+        // Do something.
     }
 }

--- a/inc/endpoints/class-cache-endpoint.php
+++ b/inc/endpoints/class-cache-endpoint.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Class file for the cache endpoint.
+ *
+ * @package WP_Irving
+ */
+namespace WP_Irving\REST_API;
+
+/**
+ * Cache Endpoint.
+ */
+class Cache_Endpoint extends Endpoint {
+    /**
+     * Attach to required hooks for endpoint.
+     */
+    public function __construct() {
+        parent::__construct();
+
+        add_action( 'rest_api_init', [ $this, 'register_rest_routes' ] );
+    }
+
+    /**
+     * Register the REST API routes.
+     */
+    public function register_rest_routes() {
+        register_rest_route(
+            self::get_namespace(),
+            '/purge-cache',
+            [
+                // 'methods'  => \WP_REST_Server::CREATABLE,
+                'methods'  => \WP_REST_Server::READABLE,
+                'callback' => [ $this, 'get_route_response' ],
+            ]
+        );
+    }
+
+	/**
+	 * Callback for the route.
+	 *
+	 * @param  WP_REST_Request $request Request object.
+	 *
+	 * @return array
+	 */
+    public function get_route_response( $request ) {
+        // phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited
+        global $wp;
+    }
+}

--- a/inc/endpoints/class-cache-endpoint.php
+++ b/inc/endpoints/class-cache-endpoint.php
@@ -56,7 +56,7 @@ class Cache_Endpoint extends Endpoint {
 
             if ( $action === 'irving_page_cache_purge' ) {
                 // Get the route.
-                $route = request_params['route'];
+                $route = $request_params['route'];
                 // Ensure the requested route is not empty prior
                 // to firing the action.
                 if ( !empty( $route ) ) {
@@ -82,7 +82,11 @@ class Cache_Endpoint extends Endpoint {
      *
      * @param string $route The target route to purge from the cache.
      */
-    public function purge_page_cache( $args ) {
-        // Do something.
+    public function purge_page_cache( $route ) {
+        // Check to see if the action is being executed on a VIP Go enabled
+        // environment. If so, use VIP's purge function.
+        if ( function_exists( 'wpcom_vip_purge_edge_cache_for_url' ) ) {
+            wpcom_vip_purge_edge_cache_for_url( $route );
+        }
     }
 }

--- a/inc/templates/admin-bar.php
+++ b/inc/templates/admin-bar.php
@@ -357,11 +357,21 @@ function get_documentation_items(): array {
  * @return array
  */
 function get_cache_items(): array {
+
 	return [
 		[
-			'id'    => 'irving-cache-purge',
+			'id'    => 'irving-cache',
 			'title' => __( 'Clear The Cache', 'wp-irving' ),
-			'href'  => '#',
+		],
+		[
+			'id'     => 'irving-cache-one',
+			'parent' => 'irving-cache',
+			'title'  => __( 'Clear Site Cache', 'wp-irving' ),
+		],
+		[
+			'id'     => 'irving-cache-two',
+			'parent' => 'irving-cache',
+			'title'  => __( 'Clear Page Cache', 'wp-irving' ),
 		],
 	];
 }
@@ -371,28 +381,21 @@ function get_cache_items(): array {
  * an action event, `wp_ajax_irving_cache_purge`, on click using WP ajax.
  */
 function cache_purge_click_listener() {
+	$rest_endpoint = esc_url( site_url( '/wp-json/irving/v1/purge-cache' ) );
 	?>
 		<script type="text/javascript">
-			jQuery('#wp-admin-bar-irving-cache-purge').on('click', function() {
-				const data = { 'action': 'irving_cache_purge' };
-				jQuery.post( '<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>', data );
+			jQuery('#wp-admin-bar-irving-cache-one').on('click', function() {
+				const data = { 'action': 'irving_site_cache_purge' };
+				jQuery.post( '<?php echo $rest_endpoint ?>', data );
+			});
+			jQuery('#wp-admin-bar-irving-cache-two').on('click', function() {
+				const data = {
+					'action': 'irving_page_cache_purge',
+					'route': 'current_route_goes_here',
+				};
+				jQuery.post( '<?php echo $rest_endpoint ?>', data );
 			});
 		</script>
 	<?php
 }
 add_action( 'admin_footer', __NAMESPACE__ . '\cache_purge_click_listener', 95 );
-
-/**
- * Purge the cache. Called when the `wp_ajax_irving_cache_purge` action
- * is fired.
- */
-function cache_purge_callback() {
-	// If the site is running on a pantheon environment, purge the cache
-	// through the `pantheon_flush_site()` method.
-	if ( function_exists( 'pantheon_wp_clear_edge_paths' ) ) {
-		\WP_Irving\Pantheon::pantheon_flush_site();
-	} else {
-		\WP_Irving\Cache::instance()->fire_wipe_request();
-	}
-}
-add_action( 'wp_ajax_irving_cache_purge', __NAMESPACE__ . '\cache_purge_callback', 100 );

--- a/inc/templates/admin-bar.php
+++ b/inc/templates/admin-bar.php
@@ -376,12 +376,12 @@ function cache_purge_click_listener() {
 		<script type="text/javascript">
 			jQuery('#wp-admin-bar-irving-cache-purge').on('click', function() {
 				const data = { 'action': 'irving_cache_purge' };
-				jQuery.post( '<?php echo admin_url( 'admin-ajax.php' ) ?>', data );
+				jQuery.post( '<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>', data );
 			});
 		</script>
 	<?php
 }
-add_action( 'admin_footer',  __NAMESPACE__ . '\cache_purge_click_listener', 95 );
+add_action( 'admin_footer', __NAMESPACE__ . '\cache_purge_click_listener', 95 );
 
 /**
  * Purge the cache. Called when the `wp_ajax_irving_cache_purge` action

--- a/inc/templates/admin-bar.php
+++ b/inc/templates/admin-bar.php
@@ -9,7 +9,6 @@ namespace WP_Irving;
 
 use WP_Irving\Components\Component;
 use WP_Irving\REST_API\Components_Endpoint;
-use WP_Irving\Cache;
 
 /**
  * Automatically insert the admin bar component.
@@ -388,6 +387,12 @@ add_action( 'admin_footer', __NAMESPACE__ . '\cache_purge_click_listener', 95 );
  * is fired.
  */
 function cache_purge_callback() {
-	Cache::instance()->fire_wipe_request();
+	// If the site is running on a pantheon environment, purge the cache
+	// through the `pantheon_flush_site()` method.
+	if ( function_exists( 'pantheon_wp_clear_edge_paths' ) ) {
+		\WP_Irving\Pantheon::instance()->pantheon_flush_site();
+	} else {
+		\WP_Irving\Cache::instance()->fire_wipe_request();
+	}
 }
 add_action( 'wp_ajax_irving_cache_purge', __NAMESPACE__ . '\cache_purge_callback', 100 );

--- a/inc/templates/admin-bar.php
+++ b/inc/templates/admin-bar.php
@@ -369,10 +369,11 @@ function get_cache_items(): array {
 		],
 	];
 
-	$is_external_env = function_exists( 'wpcom_vip_purge_edge_cache_for_url' ) || function_exists( 'patheon_wp_clear_edge_paths' );
-	// On VIP Go environments, enable the option to purge the
-	// URL specific page cache. Do not show on admin pages.
-	if ( ! is_admin() && $is_external_env ) {
+	$is_vip      = function_exists( 'wpcom_vip_purge_edge_cache_for_url' );
+	$is_pantheon = function_exists( 'patheon_wp_clear_edge_paths' );
+	// On VIP Go & pantheon environments, enable the option to purge the
+	// URL specific page cache.
+	if ( $is_vip || $is_pantheon ) {
 		$arr[] = [
 			'id'     => 'irving-cache-two',
 			'parent' => 'irving-cache',

--- a/inc/templates/admin-bar.php
+++ b/inc/templates/admin-bar.php
@@ -357,8 +357,7 @@ function get_documentation_items(): array {
  * @return array
  */
 function get_cache_items(): array {
-
-	return [
+	$arr = [
 		[
 			'id'    => 'irving-cache',
 			'title' => __( 'Clear The Cache', 'wp-irving' ),
@@ -368,12 +367,19 @@ function get_cache_items(): array {
 			'parent' => 'irving-cache',
 			'title'  => __( 'Clear Site Cache', 'wp-irving' ),
 		],
-		[
+	];
+
+	// On VIP Go environments, enable the option to purge the
+	// URL specific page cache. Do not show on admin pages.
+	if ( !is_admin() && function_exists( 'wpcom_vip_purge_edge_cache_for_url' ) ) {
+		$arr[] = [
 			'id'     => 'irving-cache-two',
 			'parent' => 'irving-cache',
 			'title'  => __( 'Clear Page Cache', 'wp-irving' ),
-		],
-	];
+		];
+	}
+
+	return $arr;
 }
 
 /**
@@ -391,7 +397,7 @@ function cache_purge_click_listener() {
 			jQuery('#wp-admin-bar-irving-cache-two').on('click', function() {
 				const data = {
 					'action': 'irving_page_cache_purge',
-					'route': 'current_route_goes_here',
+					'route': window.location.href,
 				};
 				jQuery.post( '<?php echo $rest_endpoint ?>', data );
 			});

--- a/inc/templates/admin-bar.php
+++ b/inc/templates/admin-bar.php
@@ -390,7 +390,7 @@ function cache_purge_callback() {
 	// If the site is running on a pantheon environment, purge the cache
 	// through the `pantheon_flush_site()` method.
 	if ( function_exists( 'pantheon_wp_clear_edge_paths' ) ) {
-		\WP_Irving\Pantheon::instance()->pantheon_flush_site();
+		\WP_Irving\Pantheon::pantheon_flush_site();
 	} else {
 		\WP_Irving\Cache::instance()->fire_wipe_request();
 	}

--- a/inc/templates/admin-bar.php
+++ b/inc/templates/admin-bar.php
@@ -372,7 +372,7 @@ function get_cache_items(): array {
 	$is_external_env = function_exists( 'wpcom_vip_purge_edge_cache_for_url' ) || function_exists( 'patheon_wp_clear_edge_paths' );
 	// On VIP Go environments, enable the option to purge the
 	// URL specific page cache. Do not show on admin pages.
-	if ( !is_admin() && $is_external_env ) {
+	if ( ! is_admin() && $is_external_env ) {
 		$arr[] = [
 			'id'     => 'irving-cache-two',
 			'parent' => 'irving-cache',
@@ -388,19 +388,19 @@ function get_cache_items(): array {
  * an action event, `wp_ajax_irving_cache_purge`, on click using WP ajax.
  */
 function cache_purge_click_listener() {
-	$rest_endpoint = esc_url( site_url( '/wp-json/irving/v1/purge-cache' ) );
+	$rest_endpoint = site_url( '/wp-json/irving/v1/purge-cache' );
 	?>
 		<script type="text/javascript">
 			jQuery('#wp-admin-bar-irving-cache-one').on('click', function() {
 				const data = { 'action': 'irving_site_cache_purge' };
-				jQuery.post( '<?php echo $rest_endpoint ?>', data );
+				jQuery.post( '<?php echo esc_url( $rest_endpoint ); ?>', data );
 			});
 			jQuery('#wp-admin-bar-irving-cache-two').on('click', function() {
 				const data = {
 					'action': 'irving_page_cache_purge',
 					'route': window.location.href,
 				};
-				jQuery.post( '<?php echo $rest_endpoint ?>', data );
+				jQuery.post( '<?php echo esc_url( $rest_endpoint ); ?>', data );
 			});
 		</script>
 	<?php

--- a/inc/templates/admin-bar.php
+++ b/inc/templates/admin-bar.php
@@ -369,9 +369,10 @@ function get_cache_items(): array {
 		],
 	];
 
+	$is_external_env = function_exists( 'wpcom_vip_purge_edge_cache_for_url' ) || function_exists( 'patheon_wp_clear_edge_paths' );
 	// On VIP Go environments, enable the option to purge the
 	// URL specific page cache. Do not show on admin pages.
-	if ( !is_admin() && function_exists( 'wpcom_vip_purge_edge_cache_for_url' ) ) {
+	if ( !is_admin() && $is_external_env ) {
 		$arr[] = [
 			'id'     => 'irving-cache-two',
 			'parent' => 'irving-cache',

--- a/wp-irving.php
+++ b/wp-irving.php
@@ -29,6 +29,7 @@ require_once WP_IRVING_PATH . '/inc/endpoints/class-components-endpoint.php';
 require_once WP_IRVING_PATH . '/inc/endpoints/class-components-registry-endpoint.php';
 require_once WP_IRVING_PATH . '/inc/endpoints/class-data-endpoint.php';
 require_once WP_IRVING_PATH . '/inc/endpoints/class-form-endpoint.php';
+require_once WP_IRVING_PATH . '/inc/endpoints/class-cache-endpoint.php';
 
 // Integrations.
 require_once WP_IRVING_PATH . '/inc/integrations/class-archiveless.php';
@@ -71,6 +72,7 @@ new REST_API\Components_Endpoint();
 new REST_API\Components_Registry_Endpoint();
 new REST_API\Data_Endpoint();
 new REST_API\Form_Endpoint();
+new REST_API\Cache_Endpoint();
 
 // Bootstrap functionality.
 Components\bootstrap();


### PR DESCRIPTION
This PR adds a "Clear The Cache" button to the WordPress admin bar for users that have the `manage_options` capability. On dev environments using this button will run the `fire_wipe_request()` method and on pantheon environments, the `pantheon_flush_site()` method will be targeted instead.