### PR TITLE
Resolve template parts as component children

### DIFF
--- a/inc/templates/namespace.php
+++ b/inc/templates/namespace.php
@@ -154,12 +154,6 @@ function prepare_data_from_template( string $template_path ): array {
 			// Attempt to json decode it.
 			$data = json_decode( $contents, true );
 
-			// If a template part only includes a single component,
-			// we need to wrap it in another array.
-			if ( count( $data ) > 0 && ! isset( $data[0] ) ) {
-				$data = [ $data ];
-			}
-
 			// Check for errors during decoding.
 			if ( json_last_error() ) {
 				wp_send_json_error(
@@ -424,6 +418,12 @@ function convert_blocks_to_components( array $blocks ): array {
  * @return array a data array ready for a REST response.
  */
 function hydrate_template( array $data ): array {
+
+	// Check whether the root of the template data is a single
+	// component, and wrap it in another array if so.
+	if ( count( $data ) > 0 && isset( $data['name'] ) ) {
+		$data = [ $data ];
+	}
 
 	$hydrated = [];
 

--- a/inc/templates/namespace.php
+++ b/inc/templates/namespace.php
@@ -154,6 +154,12 @@ function prepare_data_from_template( string $template_path ): array {
 			// Attempt to json decode it.
 			$data = json_decode( $contents, true );
 
+			// If a template part only includes a single component,
+			// we need to wrap it in another array.
+			if ( count( $data ) > 0 && ! isset( $data[0] ) ) {
+				$data = [ $data ];
+			}
+
 			// Check for errors during decoding.
 			if ( json_last_error() ) {
 				wp_send_json_error(

--- a/tests/templates/template-parts/example-nested.json
+++ b/tests/templates/template-parts/example-nested.json
@@ -1,5 +1,10 @@
 [
   { "name": "example/component" },
   { "name": "template-part/example" },
-  { "name": "example/component" }
+  {
+    "name": "example/component",
+    "children": [
+      { "name": "template-part/simple" }
+    ]
+  }
 ]

--- a/tests/templates/template-parts/simple.json
+++ b/tests/templates/template-parts/simple.json
@@ -1,5 +1,3 @@
-[
-  {
+{
     "name": "example/component"
-  }
-]
+}

--- a/tests/templates/template-parts/simple.json
+++ b/tests/templates/template-parts/simple.json
@@ -1,0 +1,5 @@
+[
+  {
+    "name": "example/component"
+  }
+]

--- a/tests/templates/test-templates.php
+++ b/tests/templates/test-templates.php
@@ -184,7 +184,14 @@ class Test_Templates extends WP_UnitTestCase {
 							],
 						]
 					),
-					new Component( 'example/component' ),
+					new Component(
+						'example/component',
+						[
+							'children' => [
+								[ 'name' => 'example/component' ],
+							],
+						]
+					),
 				],
 				'Nested template parts are not hydrating correctly.',
 			],


### PR DESCRIPTION
This fixes a bug where template-parts that were referenced as children of a component were not being resolved and converted to components during hydration.