### PR TITLE
Fix post list template when wrapper or item is set as an array

### DIFF
--- a/inc/components/components/post-list/component.php
+++ b/inc/components/components/post-list/component.php
@@ -59,24 +59,30 @@ register_component_from_config(
 			$post_ids = wp_list_pluck( $query->posts, 'ID' );
 			$post_ids = post_list_get_and_add_used_post_ids( $post_ids );
 
+			// Ensure single items are wrapped in an array.
+			$item = ( isset( $templates['item'][0] ) ) ? $templates['item'] : [ $templates['item'] ];
+
 			$children = array_map(
-				function ( $post_id ) use ( $templates ) {
+				function ( $post_id ) use ( $item ) {
 					return [
 						'name'     => 'irving/post-provider',
 						'config'   => [
 							'post_id' => $post_id,
 						],
-						'children' => [ $templates['item'] ],
+						'children' => $item,
 					];
 				},
 				$post_ids
 			);
 
+			// If a list of components are set as a wrapper, only use the first.
+			$wrapper = $templates['wrapper'][0] ?? $templates['wrapper'];
+
 			// Wrap the children.
-			if ( ! empty( $templates['wrapper'] ) ) {
+			if ( ! empty( $wrapper ) ) {
 				$children = [
 					array_merge(
-						$templates['wrapper'],
+						$wrapper,
 						[ 'children' => $children ]
 					),
 				];

--- a/tests/components/test-components.php
+++ b/tests/components/test-components.php
@@ -452,6 +452,22 @@ class Test_Components extends WP_UnitTestCase {
 			'item'    => [ 'name' => 'example/item' ],
 		];
 
+		// Demo templates with item and wrapper in array format.
+		$templates_alt = [
+			'before'  => [
+				[ 'name' => 'example/before' ],
+			],
+			'after'   => [
+				[ 'name' => 'example/after' ],
+			],
+			'wrapper' => [
+				[ 'name' => 'example/wrapper' ],
+			],
+			'item'    => [
+				[ 'name' => 'example/item' ],
+			],
+		];
+
 		$expected = $this->get_expected_component(
 			'irving/post-list',
 			[
@@ -492,7 +508,18 @@ class Test_Components extends WP_UnitTestCase {
 			]
 		);
 
+		$component_alt = new Component(
+			'irving/post-list',
+			[
+				'config' => [
+					'query_args' => $query_args,
+					'templates'  => $templates,
+				],
+			]
+		);
+
 		$this->assertComponentEquals( $expected, $component );
+		$this->assertComponentEquals( $expected, $component_alt );
 	}
 
 	/**


### PR DESCRIPTION
This fixes an issue where a template that had previously set the template.wrapper or template.item property as an array of items rather than a single object would break after the component refactor.

Adds a unit test case for this issue.