### PR TITLE
IRV-592: Integrations Manager

### DIFF
--- a/inc/class-integrations.php
+++ b/inc/class-integrations.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * WP Irving Integrations Manager
+ *
+ * @package WP_Irving
+ */
+
+ namespace WP_Irving;
+
+ /**
+  * Class for managing integrations in Irving.
+  */
+class Integrations {
+
+    /**
+     * Class instance.
+     *
+     * @var null|self
+     */
+    protected static $instance;
+
+    /**
+     * Get class instance.
+     *
+     * @return self
+     */
+    public static function instance() {
+        if ( ! isset( static::$instance ) ) {
+            static::$instance = new static();
+            static::$instance->setup();
+        }
+        return static::$instance;
+    }
+
+    /**
+     * Class constructor.
+     */
+    public function setup() {
+		// Register admin page.
+		add_action( 'admin_menu', [ $this, 'register_admin' ] );
+    }
+
+    /**
+     * Render the admin page in the settings submenu.
+     */
+    public function register_admin() {
+        add_submenu_page(
+            'options-general.php',
+            __( 'Irving Integrations', 'wp-irving' ),
+            __( 'Irving Integrations', 'wp-irving' ),
+            'manage_options',
+            'wp-irving-integrations',
+            [ $this, 'render' ]
+        );
+    }
+
+    /**
+     * Render the settings page.
+     */
+    public function render() {
+        ?>
+            <div class="wrap">
+                <h1 class="wp-heading-inline">
+                    <?php esc_html_e( 'WP-Irving - Integrations Manager', 'wp-irving' ); ?>
+                </h1>
+
+                <hr class="wp-header-end">
+
+                <form method="post">
+                </form>
+            </div>
+        <?php
+    }
+}
+
+add_action(
+    'init',
+    function() {
+        \WP_Irving\Integrations::instance();
+    }
+);

--- a/inc/class-integrations.php
+++ b/inc/class-integrations.php
@@ -37,7 +37,45 @@ class Integrations {
      */
     public function setup() {
 		// Register admin page.
-		add_action( 'admin_menu', [ $this, 'register_admin' ] );
+        add_action( 'admin_menu', [ $this, 'register_admin' ] );
+        // Register settings fields for integrations.
+        add_action( 'admin_init', [ $this, 'register_settings_fields' ], 10, 2 );
+    }
+
+    /**
+     * Register settings fields for display.
+     */
+    public function register_settings_fields() {
+        // Register a new setting for the integrations manager to consume/set.
+        register_setting( 'wp-irving-integrations', 'irving_integrations_options' );
+
+        // Register the section.
+        add_settings_section(
+            'irving_integrations_settings',
+            __( 'Add keys for integrations to be passed to the front-end.', 'wp-irving' ),
+            'set_irving_integrations_keys',
+            'irving_integrations'
+        );
+
+        // Register a new field for the Google Analytics integration.
+        add_settings_field(
+            'irving_integrations_ga_key',
+            __( 'Google Analytics Tracking ID', 'wp-irving' ),
+            'get_ga_key',
+            'irving_integrations_settings'
+        );
+    }
+
+    public function set_irving_integrations_keys() {
+        ?>
+            <p><?php esc_html_e( 'Follow the white rabbit.', 'wp-irving' ); ?></p>
+        <?php
+    }
+
+    public function get_ga_key() {
+        ?>
+            <p><?php esc_html_e( 'Take the red pill.', 'wp-irving' ); ?></p>
+        <?php
     }
 
     /**
@@ -67,6 +105,11 @@ class Integrations {
                 <hr class="wp-header-end">
 
                 <form method="post">
+                    <?php settings_fields( 'irving_integrations' ); ?>
+
+                    <?php do_settings_sections( 'irving_integrations' ); ?>
+
+                    <?php submit_button( __( 'Save Settings', 'wp-irving' ) ); ?>
                 </form>
             </div>
         <?php

--- a/inc/class-integrations.php
+++ b/inc/class-integrations.php
@@ -13,6 +13,12 @@
 class Integrations {
 
     /**
+     * Holds the option values to be set.
+     */
+    private $options;
+
+
+    /**
      * Class instance.
      *
      * @var null|self
@@ -47,14 +53,14 @@ class Integrations {
      */
     public function register_settings_fields() {
         // Register a new setting for the integrations manager to consume/set.
-        register_setting( 'wp-irving-integrations', 'irving_integrations' );
+        register_setting( 'wp_irving_integrations', 'irving_integrations' );
 
         // Register the section.
         add_settings_section(
             'irving_integrations_settings',
             __( 'Add keys for integrations to be passed to the front-end.', 'wp-irving' ),
-            [ $this, 'set_irving_integrations_keys' ],
-            'irving_integrations'
+            '',
+            'wp_irving_integrations'
         );
 
         // Register a new field for the Google Analytics integration.
@@ -62,7 +68,7 @@ class Integrations {
             'irving_integrations_ga_key',
             __( 'Google Analytics Tracking ID', 'wp-irving' ),
             [ $this, 'get_ga_key' ],
-            'irving_integrations',
+            'wp_irving_integrations',
             'irving_integrations_settings',
             [
                 'id' => 'irving_integrations_ga_key',
@@ -70,16 +76,11 @@ class Integrations {
         );
     }
 
-    public function set_irving_integrations_keys() {
-        ?>
-            <p><?php esc_html_e( 'Follow the white rabbit.', 'wp-irving' ); ?></p>
-        <?php
-    }
-
     public function get_ga_key( $args ) {
-        $options = get_option( 'irving_integrations_options' );
+        $ga_key = $this->options[ $args[ 'id' ] ];
+
         ?>
-            <input type="text" name="<?php echo esc_attr( $args[ 'id' ] ); ?>" value="<?php echo esc_attr( $options[ $args[ 'id' ] ] ); ?>"/>
+            <input type="text" name="irving_integrations[<?php echo esc_attr( $args[ 'id' ] ); ?>]" value="<?php echo isset( $ga_key ) ? esc_attr( $ga_key ) : '' ?>" />
         <?php
     }
 
@@ -101,13 +102,17 @@ class Integrations {
      * Render the settings page.
      */
     public function render() {
+        $this->options = get_option( 'irving_integrations' );
+
         // Check if the user have submitted the settings
         if ( isset( $_GET['settings-updated'] ) ) {
-            add_settings_error( 'irving_integrations_messages', 'irving_integrations_message', __( 'Settings Saved', 'wporg' ) );
+            add_settings_error(
+                'irving_integrations_messages',
+                'irving_integrations_message',
+                __( 'Settings Saved', 'wp-irving' ),
+                'updated'
+            );
         }
-
-         // Show error/update messages
-        settings_errors( 'irving_integrations_messages' );
 
         ?>
             <div class="wrap">
@@ -118,10 +123,8 @@ class Integrations {
                 <hr class="wp-header-end">
 
                 <form method="post" action="options.php">
-                    <?php settings_fields( 'irving_integrations' ); ?>
-
-                    <?php do_settings_sections( 'irving_integrations' ); ?>
-
+                    <?php settings_fields( 'wp_irving_integrations' ); ?>
+                    <?php do_settings_sections( 'wp_irving_integrations' ); ?>
                     <?php submit_button( __( 'Save Settings', 'wp-irving' ) ); ?>
                 </form>
             </div>

--- a/inc/class-integrations.php
+++ b/inc/class-integrations.php
@@ -10,7 +10,7 @@
  /**
   * Class for managing integrations in Irving.
   */
-class Integrations {
+class Integrations { 
 
     /**
      * Holds the option values to be set.
@@ -65,19 +65,19 @@ class Integrations {
 
         // Register a new field for the Google Analytics integration.
         add_settings_field(
-            'irving_integrations_ga_key',
+            'ga_tracking_id',
             __( 'Google Analytics Tracking ID', 'wp-irving' ),
             [ $this, 'get_ga_key' ],
             'wp_irving_integrations',
             'irving_integrations_settings',
             [
-                'id' => 'irving_integrations_ga_key',
+                'id' => 'ga_tracking_id',
             ]
         );
     }
 
     public function get_ga_key( $args ) {
-        $ga_key = $this->options[ $args[ 'id' ] ];
+        $ga_key = isset( $this->options[ $args[ 'id' ] ] ) ? $this->options[ $args[ 'id' ] ] : '';
 
         ?>
             <input type="text" name="irving_integrations[<?php echo esc_attr( $args[ 'id' ] ); ?>]" value="<?php echo isset( $ga_key ) ? esc_attr( $ga_key ) : '' ?>" />

--- a/inc/class-integrations.php
+++ b/inc/class-integrations.php
@@ -47,7 +47,7 @@ class Integrations {
      */
     public function register_settings_fields() {
         // Register a new setting for the integrations manager to consume/set.
-        register_setting( 'wp-irving-integrations', 'irving_integrations_options' );
+        register_setting( 'wp-irving-integrations', 'irving_integrations' );
 
         // Register the section.
         add_settings_section(
@@ -61,8 +61,12 @@ class Integrations {
         add_settings_field(
             'irving_integrations_ga_key',
             __( 'Google Analytics Tracking ID', 'wp-irving' ),
-            'get_ga_key',
-            'irving_integrations_settings'
+            [ $this, 'get_ga_key' ],
+            'irving_integrations',
+            'irving_integrations_settings',
+            [
+                'id' => 'irving_integrations_ga_key',
+            ]
         );
     }
 
@@ -72,9 +76,10 @@ class Integrations {
         <?php
     }
 
-    public function get_ga_key() {
+    public function get_ga_key( $args ) {
+        $options = get_option( 'irving_integrations_options' );
         ?>
-            <p><?php esc_html_e( 'Take the red pill.', 'wp-irving' ); ?></p>
+            <input type="text" name="<?php echo esc_attr( $args[ 'id' ] ); ?>" value="<?php echo esc_attr( $options[ $args[ 'id' ] ] ); ?>"/>
         <?php
     }
 
@@ -96,6 +101,14 @@ class Integrations {
      * Render the settings page.
      */
     public function render() {
+        // Check if the user have submitted the settings
+        if ( isset( $_GET['settings-updated'] ) ) {
+            add_settings_error( 'irving_integrations_messages', 'irving_integrations_message', __( 'Settings Saved', 'wporg' ) );
+        }
+
+         // Show error/update messages
+        settings_errors( 'irving_integrations_messages' );
+
         ?>
             <div class="wrap">
                 <h1 class="wp-heading-inline">
@@ -104,7 +117,7 @@ class Integrations {
 
                 <hr class="wp-header-end">
 
-                <form method="post">
+                <form method="post" action="options.php">
                     <?php settings_fields( 'irving_integrations' ); ?>
 
                     <?php do_settings_sections( 'irving_integrations' ); ?>

--- a/inc/class-integrations.php
+++ b/inc/class-integrations.php
@@ -53,7 +53,7 @@ class Integrations {
         add_settings_section(
             'irving_integrations_settings',
             __( 'Add keys for integrations to be passed to the front-end.', 'wp-irving' ),
-            'set_irving_integrations_keys',
+            [ $this, 'set_irving_integrations_keys' ],
             'irving_integrations'
         );
 

--- a/inc/integrations/class-archiveless.php
+++ b/inc/integrations/class-archiveless.php
@@ -31,6 +31,9 @@ class Archiveless {
 		return static::$instance;
 	}
 
+	/**
+	 * Constructor for class.
+	 */
 	public function setup() {
 		// Ensure Archiveless exists and is enabled.
 		if ( ! class_exists( '\Archiveless' ) ) {

--- a/inc/integrations/class-archiveless.php
+++ b/inc/integrations/class-archiveless.php
@@ -5,7 +5,7 @@
  * @package WP_Irving;
  */
 
-namespace WP_Irving;
+namespace WP_Irving\Integrations;
 
 /**
  * Class to replicate Archiveless's query modifications.
@@ -13,9 +13,25 @@ namespace WP_Irving;
 class Archiveless {
 
 	/**
-	 * Constructor for class.
+	 * Class instance.
+	 *
+	 * @var null|self
 	 */
-	public function __construct() {
+	protected static $instance;
+
+	/**
+	 * Get class instance.
+	 *
+	 * @return self
+	 */
+	public static function instance() {
+		if ( ! isset( static::$instance ) ) {
+			static::$instance = new static();
+		}
+		return static::$instance;
+	}
+
+	public function setup() {
 		// Ensure Archiveless exists and is enabled.
 		if ( ! class_exists( '\Archiveless' ) ) {
 			return;
@@ -59,11 +75,3 @@ class Archiveless {
 		return $where;
 	}
 }
-
-add_action(
-	'init',
-	function() {
-		new \WP_Irving\Archiveless();
-	} 
-);
-

--- a/inc/integrations/class-google-amp.php
+++ b/inc/integrations/class-google-amp.php
@@ -5,7 +5,7 @@
  * @package WP_Irving;
  */
 
-namespace WP_Irving;
+namespace WP_Irving\Integrations;
 
 /**
  * Class to integrate Google AMP with Irving.
@@ -13,9 +13,28 @@ namespace WP_Irving;
 class Google_AMP {
 
 	/**
+	 * Class instance.
+	 *
+	 * @var null|self
+	 */
+	protected static $instance;
+
+	/**
+	 * Get class instance.
+	 *
+	 * @return self
+	 */
+	public static function instance() {
+		if ( ! isset( static::$instance ) ) {
+			static::$instance = new static();
+		}
+		return static::$instance;
+	}
+
+	/**
 	 * Constructor for class.
 	 */
-	public function __construct() {
+	public function setup() {
 
 		// Ensure the AMP plugin exists and is enabled.
 		if ( ! function_exists( 'is_amp_endpoint' ) ) {
@@ -37,10 +56,3 @@ class Google_AMP {
 		}
 	}
 }
-
-add_action(
-	'init',
-	function() {
-		new \WP_Irving\Google_AMP();
-	}
-);

--- a/inc/integrations/class-google-analytics.php
+++ b/inc/integrations/class-google-analytics.php
@@ -74,8 +74,6 @@ class Google_Analytics {
 
 	/**
 	 * Render an input for the GA Tracking ID.
-	 *
-	 * @param array $args Arguments for input.
 	 */
 	public function render_tracking_id_input() {
 		// Check to see if there is an existing GA configuration in the option.

--- a/inc/integrations/class-google-analytics.php
+++ b/inc/integrations/class-google-analytics.php
@@ -68,10 +68,7 @@ class Google_Analytics {
 			esc_html__( 'Google Analytics Tracking ID', 'wp-irving' ),
 			[ $this, 'render_tracking_id_input' ],
 			'wp_irving_integrations',
-			'irving_integrations_settings',
-			[
-				'id' => 'tracking_id',
-			]
+			'irving_integrations_settings'
 		);
 	}
 
@@ -80,12 +77,12 @@ class Google_Analytics {
 	 *
 	 * @param array $args Arguments for input.
 	 */
-	public function render_tracking_id_input( array $args ) {
+	public function render_tracking_id_input() {
 		// Check to see if there is an existing GA configuration in the option.
-		$ga_key = $this->options['google_analytics'][ $args['id'] ] ?? '';
+		$ga_key = $this->options[ $this->option_key ]['tracking_id'] ?? '';
 
 		?>
-			<input type="text" name="irving_integrations[<?php echo esc_attr( 'ga_' . $args['id'] ); ?>]" value="<?php echo esc_attr( $ga_key ); ?>" />
+			<input type="text" name="irving_integrations[<?php echo esc_attr( 'ga_tracking_id' ); ?>]" value="<?php echo esc_attr( $ga_key ); ?>" />
 		<?php
 	}
 

--- a/inc/integrations/class-google-analytics.php
+++ b/inc/integrations/class-google-analytics.php
@@ -14,6 +14,8 @@ class Google_Analytics {
 
 	/**
 	 * Holds the option values to be set.
+	 *
+	 * @var array
 	 */
 	private $options;
 
@@ -27,7 +29,7 @@ class Google_Analytics {
 		// Register settings fields for integrations.
 		add_action( 'admin_init', [ $this, 'register_settings_fields' ], 10, 2 );
 		// Filter the updated option values prior to submission.
-		add_filter( 'pre_update_option_irving_integrations', [ $this, 'format_option_for_update' ], 10, 2);
+		add_filter( 'pre_update_option_irving_integrations', [ $this, 'format_option_for_update' ], 10, 2 );
 	}
 
 	/**
@@ -49,21 +51,23 @@ class Google_Analytics {
 
 	/**
 	 * Render an input for the GA Tracking ID.
+	 *
+	 * @param array $args Arguments for input.
 	 */
 	public function render_tracking_id_input( $args ) {
 		// Check to see if there is an existing GA configuration in the option.
-		$option = isset( $this->options['google_analytics'] ) ? $this->options['google_analytics'][ $args[ 'id' ] ] : '';
+		$option = isset( $this->options['google_analytics'] ) ? $this->options['google_analytics'][ $args['id'] ] : '';
 		$ga_key = ! empty( $option ) ? $option : '';
 
 		?>
-			<input type="text" name="irving_integrations[<?php echo esc_attr( 'ga_' . $args[ 'id' ] ); ?>]" value="<?php echo esc_attr( $ga_key ); ?>" />
+			<input type="text" name="irving_integrations[<?php echo esc_attr( 'ga_' . $args['id'] ); ?>]" value="<?php echo esc_attr( $ga_key ); ?>" />
 		<?php
 	}
 
 	/**
 	 * Group the updated options based on the integration prefix.
 	 *
-	 * @param array  $options The updated options.
+	 * @param array $options The updated options.
 	 * @return array $arr The formatted options.
 	 */
 	public function format_option_for_update( $options ): array {
@@ -73,7 +77,7 @@ class Google_Analytics {
 		foreach ( $options as $option_key => $option_val ) {
 			// Build the config array for Google Analytics.
 			if ( strpos( $option_key, 'ga_' ) !== false ) {
-				$arr['google_analytics'][str_replace( 'ga_', '', $option_key )] = $option_val;
+				$arr['google_analytics'][ str_replace( 'ga_', '', $option_key ) ] = $option_val;
 			}
 		}
 

--- a/inc/integrations/class-google-analytics.php
+++ b/inc/integrations/class-google-analytics.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * WP Irving integration for Google Analytics.
+ *
+ * @package WP_Irving;
+ */
+
+namespace WP_Irving;
+
+/**
+ * Class to integrate Google Analytics with Irving.
+ */
+class Google_Analytics {
+    
+    /**
+     * Holds the option values to be set.
+     */
+    private $options;
+
+	/**
+	 * Constructor for class.
+	 */
+	public function __construct() {
+        // Retrieve any existing integrations options.
+        $this->options = get_option( 'irving_integrations' );
+
+        // Register settings fields for integrations.
+        add_action( 'admin_init', [ $this, 'register_settings_fields' ], 10, 2 );
+        // Filter the updated option values prior to submission.
+        add_filter( 'pre_update_option_irving_integrations', [ $this, 'format_option_for_update' ], 10, 2);
+    }
+
+    /**
+     * Register settings fields for display.
+     */
+    public function register_settings_fields() {
+        // Register a new field for the Google Analytics integration.
+        add_settings_field(
+            'ga_tracking_id',
+            __( 'Google Analytics Tracking ID', 'wp-irving' ),
+            [ $this, 'render_tracking_id_input' ],
+            'wp_irving_integrations',
+            'irving_integrations_settings',
+            [
+                'id' => 'tracking_id',
+            ]
+        );
+    }
+
+    /**
+     * Render an input for the GA Tracking ID.
+     */
+    public function render_tracking_id_input( $args ) {
+        // Check to see if there is an existing GA configuration in the option.
+        $option = isset( $this->options['google_analytics'] ) ? $this->options['google_analytics'][ $args[ 'id' ] ] : '';
+        $ga_key = ! empty( $option ) ? $option : '';
+
+        ?>
+            <input type="text" name="irving_integrations[<?php echo esc_attr( 'ga_' . $args[ 'id' ] ); ?>]" value="<?php echo esc_attr( $ga_key ); ?>" />
+        <?php
+    }
+
+    /**
+     * Group the updated options based on the integration prefix.
+     *
+     * @param array  $options The updated options.
+     * @return array $arr The formatted options.
+     */
+    public function format_option_for_update( $options ): array {
+        // Construct an empty array.
+        $arr = [];
+  
+        foreach ( $options as $option_key => $option_val ) {
+          // Build the config array for Google Analytics.
+          if ( strpos( $option_key, 'ga_' ) !== false ) {
+              $arr['google_analytics'][str_replace( 'ga_', '', $option_key )] = $option_val;
+          }
+        }
+  
+        return $arr;
+    }
+
+}
+
+add_action(
+	'init',
+	function() {
+		new \WP_Irving\Google_Analytics();
+	}
+);

--- a/inc/integrations/class-google-analytics.php
+++ b/inc/integrations/class-google-analytics.php
@@ -11,74 +11,74 @@ namespace WP_Irving;
  * Class to integrate Google Analytics with Irving.
  */
 class Google_Analytics {
-    
-    /**
-     * Holds the option values to be set.
-     */
-    private $options;
+
+	/**
+	 * Holds the option values to be set.
+	 */
+	private $options;
 
 	/**
 	 * Constructor for class.
 	 */
 	public function __construct() {
-        // Retrieve any existing integrations options.
-        $this->options = get_option( 'irving_integrations' );
+		// Retrieve any existing integrations options.
+		$this->options = get_option( 'irving_integrations' );
 
-        // Register settings fields for integrations.
-        add_action( 'admin_init', [ $this, 'register_settings_fields' ], 10, 2 );
-        // Filter the updated option values prior to submission.
-        add_filter( 'pre_update_option_irving_integrations', [ $this, 'format_option_for_update' ], 10, 2);
-    }
+		// Register settings fields for integrations.
+		add_action( 'admin_init', [ $this, 'register_settings_fields' ], 10, 2 );
+		// Filter the updated option values prior to submission.
+		add_filter( 'pre_update_option_irving_integrations', [ $this, 'format_option_for_update' ], 10, 2);
+	}
 
-    /**
-     * Register settings fields for display.
-     */
-    public function register_settings_fields() {
-        // Register a new field for the Google Analytics integration.
-        add_settings_field(
-            'ga_tracking_id',
-            __( 'Google Analytics Tracking ID', 'wp-irving' ),
-            [ $this, 'render_tracking_id_input' ],
-            'wp_irving_integrations',
-            'irving_integrations_settings',
-            [
-                'id' => 'tracking_id',
-            ]
-        );
-    }
+	/**
+	 * Register settings fields for display.
+	 */
+	public function register_settings_fields() {
+		// Register a new field for the Google Analytics integration.
+		add_settings_field(
+			'ga_tracking_id',
+			__( 'Google Analytics Tracking ID', 'wp-irving' ),
+			[ $this, 'render_tracking_id_input' ],
+			'wp_irving_integrations',
+			'irving_integrations_settings',
+			[
+				'id' => 'tracking_id',
+			]
+		);
+	}
 
-    /**
-     * Render an input for the GA Tracking ID.
-     */
-    public function render_tracking_id_input( $args ) {
-        // Check to see if there is an existing GA configuration in the option.
-        $option = isset( $this->options['google_analytics'] ) ? $this->options['google_analytics'][ $args[ 'id' ] ] : '';
-        $ga_key = ! empty( $option ) ? $option : '';
+	/**
+	 * Render an input for the GA Tracking ID.
+	 */
+	public function render_tracking_id_input( $args ) {
+		// Check to see if there is an existing GA configuration in the option.
+		$option = isset( $this->options['google_analytics'] ) ? $this->options['google_analytics'][ $args[ 'id' ] ] : '';
+		$ga_key = ! empty( $option ) ? $option : '';
 
-        ?>
-            <input type="text" name="irving_integrations[<?php echo esc_attr( 'ga_' . $args[ 'id' ] ); ?>]" value="<?php echo esc_attr( $ga_key ); ?>" />
-        <?php
-    }
+		?>
+			<input type="text" name="irving_integrations[<?php echo esc_attr( 'ga_' . $args[ 'id' ] ); ?>]" value="<?php echo esc_attr( $ga_key ); ?>" />
+		<?php
+	}
 
-    /**
-     * Group the updated options based on the integration prefix.
-     *
-     * @param array  $options The updated options.
-     * @return array $arr The formatted options.
-     */
-    public function format_option_for_update( $options ): array {
-        // Construct an empty array.
-        $arr = [];
-  
-        foreach ( $options as $option_key => $option_val ) {
-          // Build the config array for Google Analytics.
-          if ( strpos( $option_key, 'ga_' ) !== false ) {
-              $arr['google_analytics'][str_replace( 'ga_', '', $option_key )] = $option_val;
-          }
-        }
-  
-        return $arr;
-    }
+	/**
+	 * Group the updated options based on the integration prefix.
+	 *
+	 * @param array  $options The updated options.
+	 * @return array $arr The formatted options.
+	 */
+	public function format_option_for_update( $options ): array {
+		// Construct an empty array.
+		$arr = [];
+
+		foreach ( $options as $option_key => $option_val ) {
+			// Build the config array for Google Analytics.
+			if ( strpos( $option_key, 'ga_' ) !== false ) {
+				$arr['google_analytics'][str_replace( 'ga_', '', $option_key )] = $option_val;
+			}
+		}
+
+		return $arr;
+	}
 
 }
 

--- a/inc/integrations/class-integrations-manager.php
+++ b/inc/integrations/class-integrations-manager.php
@@ -5,11 +5,11 @@
  * @package WP_Irving
  */
 
- namespace WP_Irving;
+namespace WP_Irving;
 
- /**
-  * Class for managing integrations in Irving.
-  */
+/**
+ * Class for managing integrations in Irving.
+ */
 class Integrations_Manager {
 
 	/**
@@ -76,7 +76,7 @@ class Integrations_Manager {
 	 */
 	public function render() {
 		// Check if the user have submitted the settings.
-		if ( isset( $_GET['settings-updated'] ) ) {
+		if ( isset( $_GET['settings-updated'] ) ) { // phpcs:ignore
 			add_settings_error(
 				'irving_integrations_messages',
 				'irving_integrations_message',

--- a/inc/integrations/class-integrations-manager.php
+++ b/inc/integrations/class-integrations-manager.php
@@ -12,100 +12,100 @@
   */
 class Integrations_Manager {
 
-    /**
-     * Class instance.
-     *
-     * @var null|self
-     */
-    protected static $instance;
+	/**
+	 * Class instance.
+	 *
+	 * @var null|self
+	 */
+	protected static $instance;
 
-    /**
-     * Get class instance.
-     *
-     * @return self
-     */
-    public static function instance() {
-        if ( ! isset( static::$instance ) ) {
-            static::$instance = new static();
-            static::$instance->setup();
-        }
-        return static::$instance;
-    }
+	/**
+	 * Get class instance.
+	 *
+	 * @return self
+	 */
+	public static function instance() {
+		if ( ! isset( static::$instance ) ) {
+			static::$instance = new static();
+			static::$instance->setup();
+		}
+		return static::$instance;
+	}
 
-    /**
-     * Class constructor.
-     */
-    public function setup() {
-        // Register admin page.
-        add_action( 'admin_menu', [ $this, 'register_admin' ] );
-        // Register settings fields for integrations.
-        add_action( 'admin_init', [ $this, 'register_settings_fields' ], 10, 2 );
-    }
+	/**
+	 * Class constructor.
+	 */
+	public function setup() {
+		// Register admin page.
+		add_action( 'admin_menu', [ $this, 'register_admin' ] );
+		// Register settings fields for integrations.
+		add_action( 'admin_init', [ $this, 'register_settings_fields' ], 10, 2 );
+	}
 
-    /**
-     * Register settings fields for display.
-     */
-    public function register_settings_fields() {
-        // Register a new setting for the integrations manager to consume/set.
-        register_setting( 'wp_irving_integrations', 'irving_integrations' );
-        // Register the section.
-        add_settings_section(
-            'irving_integrations_settings',
-            __( 'Add keys for integrations to be passed to the front-end.', 'wp-irving' ),
-            '',
-            'wp_irving_integrations'
-        );
-    }
+	/**
+	 * Register settings fields for display.
+	 */
+	public function register_settings_fields() {
+		// Register a new setting for the integrations manager to consume/set.
+		register_setting( 'wp_irving_integrations', 'irving_integrations' );
+		// Register the section.
+		add_settings_section(
+			'irving_integrations_settings',
+			__( 'Add keys for integrations to be passed to the front-end.', 'wp-irving' ),
+			'',
+			'wp_irving_integrations'
+		);
+	}
 
-    /**
-     * Render the admin page in the settings submenu.
-     */
-    public function register_admin() {
-        add_submenu_page(
-            'options-general.php',
-            __( 'Irving Integrations', 'wp-irving' ),
-            __( 'Irving Integrations', 'wp-irving' ),
-            'manage_options',
-            'wp-irving-integrations',
-            [ $this, 'render' ]
-        );
-    }
+	/**
+	 * Render the admin page in the settings submenu.
+	 */
+	public function register_admin() {
+		add_submenu_page(
+			'options-general.php',
+			__( 'Irving Integrations', 'wp-irving' ),
+			__( 'Irving Integrations', 'wp-irving' ),
+			'manage_options',
+			'wp-irving-integrations',
+			[ $this, 'render' ]
+		);
+	}
 
-    /**
-     * Render the settings page.
-     */
-    public function render() {
-        // Check if the user have submitted the settings
-        if ( isset( $_GET['settings-updated'] ) ) {
-            add_settings_error(
-                'irving_integrations_messages',
-                'irving_integrations_message',
-                __( 'Settings Saved', 'wp-irving' ),
-                'updated'
-            );
-        }
+	/**
+	 * Render the settings page.
+	 */
+	public function render() {
+		// Check if the user have submitted the settings
+		if ( isset( $_GET['settings-updated'] ) ) {
+			add_settings_error(
+				'irving_integrations_messages',
+				'irving_integrations_message',
+				__( 'Settings Saved', 'wp-irving' ),
+				'updated'
+			);
+		}
 
-        ?>
-            <div class="wrap">
-                <h1 class="wp-heading-inline">
-                    <?php esc_html_e( 'WP-Irving - Integrations Manager', 'wp-irving' ); ?>
-                </h1>
+		?>
+			<div class="wrap">
+				<h1 class="wp-heading-inline">
+					<?php esc_html_e( 'WP-Irving - Integrations Manager', 'wp-irving' ); ?>
+				</h1>
 
-                <hr class="wp-header-end">
+				<hr class="wp-header-end">
 
-                <form method="post" action="options.php">
-                    <?php settings_fields( 'wp_irving_integrations' ); ?>
-                    <?php do_settings_sections( 'wp_irving_integrations' ); ?>
-                    <?php submit_button( __( 'Save Settings', 'wp-irving' ) ); ?>
-                </form>
-            </div>
-        <?php
-    }
+				<form method="post" action="options.php">
+					<?php settings_fields( 'wp_irving_integrations' ); ?>
+					<?php do_settings_sections( 'wp_irving_integrations' ); ?>
+					<?php submit_button( __( 'Save Settings', 'wp-irving' ) ); ?>
+				</form>
+			</div>
+		<?php
+	}
 }
 
 add_action(
-    'init',
-    function() {
-        \WP_Irving\Integrations_Manager::instance();
-    }
+	'init',
+	function() {
+		\WP_Irving\Integrations_Manager::instance();
+	}
 );

--- a/inc/integrations/class-integrations-manager.php
+++ b/inc/integrations/class-integrations-manager.php
@@ -35,77 +35,13 @@ class Integrations_Manager {
 	}
 
 	/**
-	 * Instantiate each integration's class instance and run through its setup procedures.
+	 * Register the manager's page and settings fields.
 	 */
-	public function setup_integrations() {
+	public function setup() {
 		// Register admin page.
 		add_action( 'admin_menu', [ $this, 'register_admin' ] );
 		// Register settings fields for integrations.
 		add_action( 'admin_init', [ $this, 'register_settings_fields' ] );
-
-		// Archiveless.
-		$archiveless = (
-			new \WP_Irving\Integrations\Archiveless()
-		)::instance();
-		$archiveless->setup();
-
-		// Google Analytics.
-		$google_analytics = (
-			new \WP_Irving\Integrations\Google_Analytics()
-		)::instance();
-		$google_analytics->setup();
-
-		// Google AMP.
-		$google_amp = (
-			new \WP_Irving\Integrations\Google_AMP()
-		)::instance();
-		$google_amp->setup();
-
-		// New Relic.
-		$new_relic = (
-			new \WP_Irving\Integrations\New_Relic()
-		)::instance();
-		$new_relic->setup();
-
-		// Pantheon.
-		$pantheon = (
-			new \WP_Irving\Integrations\Pantheon()
-		)::instance();
-		$pantheon->setup();
-
-		// Safe Redirect Manager.
-		$safe_redirect_manager = (
-			new \WP_Irving\Integrations\Safe_Redirect_Manager()
-		)::instance();
-		$safe_redirect_manager->setup();
-
-		// VIP Go.
-		$vip_go = (
-			new \WP_Irving\Integrations\VIP_Go()
-		)::instance();
-		$vip_go->setup();
-
-		// WPCOM Legacy Redirector.
-		$wpcom_legacy_redirector = (
-			new \WP_Irving\Integrations\WPCOM_Legacy_Redirector()
-		)::instance();
-		$wpcom_legacy_redirector->setup();
-
-		// Yoast.
-		$yoast = (
-			new \WP_Irving\Integrations\Yoast()
-		)::instance();
-		$yoast->setup();
-	}
-
-	/**
-	 * Instantiate each plugin integration's class instance and run through its setup procedures.
-	 */
-	public function setup_plugin_integrations() {
-		$jwt_auth = (
-			new \WP_Irving\Integrations\JWT_Auth()
-		)::instance();
-		$jwt_auth->setup();
 	}
 
 	/**

--- a/inc/integrations/class-integrations-manager.php
+++ b/inc/integrations/class-integrations-manager.php
@@ -75,7 +75,7 @@ class Integrations_Manager {
 	 * Render the settings page.
 	 */
 	public function render() {
-		// Check if the user have submitted the settings
+		// Check if the user have submitted the settings.
 		if ( isset( $_GET['settings-updated'] ) ) {
 			add_settings_error(
 				'irving_integrations_messages',

--- a/inc/integrations/class-integrations-manager.php
+++ b/inc/integrations/class-integrations-manager.php
@@ -1,11 +1,14 @@
 <?php
 /**
- * WP Irving Integrations Manager
+ * WP Irving Integrations Manager.
+ *
+ * Register a settings page that manages integration key/value pairs to be sent
+ * to the front end using the components API.
  *
  * @package WP_Irving
  */
 
-namespace WP_Irving;
+namespace WP_Irving\Integrations;
 
 /**
  * Class for managing integrations in Irving.
@@ -27,19 +30,82 @@ class Integrations_Manager {
 	public static function instance() {
 		if ( ! isset( static::$instance ) ) {
 			static::$instance = new static();
-			static::$instance->setup();
 		}
 		return static::$instance;
 	}
 
 	/**
-	 * Class constructor.
+	 * Instantiate each integration's class instance and run through its setup procedures.
 	 */
-	public function setup() {
+	public function setup_integrations() {
 		// Register admin page.
 		add_action( 'admin_menu', [ $this, 'register_admin' ] );
 		// Register settings fields for integrations.
-		add_action( 'admin_init', [ $this, 'register_settings_fields' ], 10, 2 );
+		add_action( 'admin_init', [ $this, 'register_settings_fields' ] );
+
+		// Archiveless.
+		$archiveless = (
+			new \WP_Irving\Integrations\Archiveless()
+		)::instance();
+		$archiveless->setup();
+
+		// Google Analytics.
+		$google_analytics = (
+			new \WP_Irving\Integrations\Google_Analytics()
+		)::instance();
+		$google_analytics->setup();
+
+		// Google AMP.
+		$google_amp = (
+			new \WP_Irving\Integrations\Google_AMP()
+		)::instance();
+		$google_amp->setup();
+
+		// New Relic.
+		$new_relic = (
+			new \WP_Irving\Integrations\New_Relic()
+		)::instance();
+		$new_relic->setup();
+
+		// Pantheon.
+		$pantheon = (
+			new \WP_Irving\Integrations\Pantheon()
+		)::instance();
+		$pantheon->setup();
+
+		// Safe Redirect Manager.
+		$safe_redirect_manager = (
+			new \WP_Irving\Integrations\Safe_Redirect_Manager()
+		)::instance();
+		$safe_redirect_manager->setup();
+
+		// VIP Go.
+		$vip_go = (
+			new \WP_Irving\Integrations\VIP_Go()
+		)::instance();
+		$vip_go->setup();
+
+		// WPCOM Legacy Redirector.
+		$wpcom_legacy_redirector = (
+			new \WP_Irving\Integrations\WPCOM_Legacy_Redirector()
+		)::instance();
+		$wpcom_legacy_redirector->setup();
+
+		// Yoast.
+		$yoast = (
+			new \WP_Irving\Integrations\Yoast()
+		)::instance();
+		$yoast->setup();
+	}
+
+	/**
+	 * Instantiate each plugin integration's class instance and run through its setup procedures.
+	 */
+	public function setup_plugin_integrations() {
+		$jwt_auth = (
+			new \WP_Irving\Integrations\JWT_Auth()
+		)::instance();
+		$jwt_auth->setup();
 	}
 
 	/**
@@ -63,8 +129,8 @@ class Integrations_Manager {
 	public function register_admin() {
 		add_submenu_page(
 			'options-general.php',
-			__( 'Irving Integrations', 'wp-irving' ),
-			__( 'Irving Integrations', 'wp-irving' ),
+			esc_html__( 'Irving Integrations', 'wp-irving' ),
+			esc_html__( 'Irving Integrations', 'wp-irving' ),
 			'manage_options',
 			'wp-irving-integrations',
 			[ $this, 'render' ]
@@ -80,7 +146,7 @@ class Integrations_Manager {
 			add_settings_error(
 				'irving_integrations_messages',
 				'irving_integrations_message',
-				__( 'Settings Saved', 'wp-irving' ),
+				esc_html__( 'Settings Saved', 'wp-irving' ),
 				'updated'
 			);
 		}
@@ -88,7 +154,7 @@ class Integrations_Manager {
 		?>
 			<div class="wrap">
 				<h1 class="wp-heading-inline">
-					<?php esc_html_e( 'WP-Irving - Integrations Manager', 'wp-irving' ); ?>
+					<?php esc_html_e( 'WP Irving - Integrations Manager', 'wp-irving' ); ?>
 				</h1>
 
 				<hr class="wp-header-end">
@@ -102,10 +168,3 @@ class Integrations_Manager {
 		<?php
 	}
 }
-
-add_action(
-	'init',
-	function() {
-		\WP_Irving\Integrations_Manager::instance();
-	}
-);

--- a/inc/integrations/class-integrations-manager.php
+++ b/inc/integrations/class-integrations-manager.php
@@ -10,13 +10,7 @@
  /**
   * Class for managing integrations in Irving.
   */
-class Integrations { 
-
-    /**
-     * Holds the option values to be set.
-     */
-    private $options;
-
+class Integrations_Manager {
 
     /**
      * Class instance.
@@ -42,7 +36,7 @@ class Integrations {
      * Class constructor.
      */
     public function setup() {
-		// Register admin page.
+        // Register admin page.
         add_action( 'admin_menu', [ $this, 'register_admin' ] );
         // Register settings fields for integrations.
         add_action( 'admin_init', [ $this, 'register_settings_fields' ], 10, 2 );
@@ -54,7 +48,6 @@ class Integrations {
     public function register_settings_fields() {
         // Register a new setting for the integrations manager to consume/set.
         register_setting( 'wp_irving_integrations', 'irving_integrations' );
-
         // Register the section.
         add_settings_section(
             'irving_integrations_settings',
@@ -62,26 +55,6 @@ class Integrations {
             '',
             'wp_irving_integrations'
         );
-
-        // Register a new field for the Google Analytics integration.
-        add_settings_field(
-            'ga_tracking_id',
-            __( 'Google Analytics Tracking ID', 'wp-irving' ),
-            [ $this, 'get_ga_key' ],
-            'wp_irving_integrations',
-            'irving_integrations_settings',
-            [
-                'id' => 'ga_tracking_id',
-            ]
-        );
-    }
-
-    public function get_ga_key( $args ) {
-        $ga_key = isset( $this->options[ $args[ 'id' ] ] ) ? $this->options[ $args[ 'id' ] ] : '';
-
-        ?>
-            <input type="text" name="irving_integrations[<?php echo esc_attr( $args[ 'id' ] ); ?>]" value="<?php echo isset( $ga_key ) ? esc_attr( $ga_key ) : '' ?>" />
-        <?php
     }
 
     /**
@@ -102,8 +75,6 @@ class Integrations {
      * Render the settings page.
      */
     public function render() {
-        $this->options = get_option( 'irving_integrations' );
-
         // Check if the user have submitted the settings
         if ( isset( $_GET['settings-updated'] ) ) {
             add_settings_error(
@@ -135,6 +106,6 @@ class Integrations {
 add_action(
     'init',
     function() {
-        \WP_Irving\Integrations::instance();
+        \WP_Irving\Integrations_Manager::instance();
     }
 );

--- a/inc/integrations/class-jwt-auth.php
+++ b/inc/integrations/class-jwt-auth.php
@@ -5,7 +5,7 @@
  * @package WP_Irving
  */
 
-namespace WP_Irving;
+namespace WP_Irving\Integrations;
 
 /**
  * Singleton class for creating a cross-domain cookie with a JSON Web Token
@@ -42,7 +42,6 @@ class JWT_Auth {
 	public static function instance() {
 		if ( ! isset( static::$instance ) ) {
 			static::$instance = new static();
-			static::$instance->setup();
 		}
 		return static::$instance;
 	}
@@ -244,10 +243,3 @@ class JWT_Auth {
 		return [];
 	}
 }
-
-add_action(
-	'plugins_loaded',
-	function() {
-		( new \WP_Irving\JWT_Auth() )->instance();
-	}
-);

--- a/inc/integrations/class-new-relic.php
+++ b/inc/integrations/class-new-relic.php
@@ -5,7 +5,7 @@
  * @package WP_Irving
  */
 
-namespace WP_Irving;
+namespace WP_Irving\Integrations;
 
 /**
  * Class to integrate New Relic with Irving.
@@ -13,9 +13,28 @@ namespace WP_Irving;
 class New_Relic {
 
 	/**
+	 * Class instance.
+	 *
+	 * @var null|self
+	 */
+	protected static $instance;
+
+	/**
+	 * Get class instance.
+	 *
+	 * @return self
+	 */
+	public static function instance() {
+		if ( ! isset( static::$instance ) ) {
+			static::$instance = new static();
+		}
+		return static::$instance;
+	}
+
+	/**
 	 * Constructor for class.
 	 */
-	public function __construct() {
+	public function setup() {
 		remove_action( 'rest_dispatch_request', 'wpcom_vip_rest_routes_for_newrelic' );
 		add_filter( 'rest_dispatch_request', [ $this, 'rest_routes_for_newrelic' ], 10, 4 );
 	}
@@ -68,10 +87,3 @@ class New_Relic {
 		return $dispatch_result;
 	}
 }
-
-add_action(
-	'init',
-	function() {
-		new \WP_Irving\New_Relic();
-	}
-);

--- a/inc/integrations/class-pantheon.php
+++ b/inc/integrations/class-pantheon.php
@@ -5,7 +5,7 @@
  * @package WP_Irving;
  */
 
-namespace WP_Irving;
+namespace WP_Irving\Integrations;
 
 /**
  * Class to handle modifications specific to Pantheon.
@@ -13,9 +13,28 @@ namespace WP_Irving;
 class Pantheon {
 
 	/**
+	 * Class instance.
+	 *
+	 * @var null|self
+	 */
+	protected static $instance;
+
+	/**
+	 * Get class instance.
+	 *
+	 * @return self
+	 */
+	public static function instance() {
+		if ( ! isset( static::$instance ) ) {
+			static::$instance = new static();
+		}
+		return static::$instance;
+	}
+
+	/**
 	 * Constructor for class.
 	 */
-	public function __construct() {
+	public function setup() {
 		if ( ! function_exists( 'pantheon_wp_clear_edge_paths' ) ) {
 			return;
 		}
@@ -76,10 +95,3 @@ class Pantheon {
 		}
 	}
 }
-
-add_action(
-	'init',
-	function() {
-		new \WP_Irving\Pantheon();
-	}
-);

--- a/inc/integrations/class-safe-redirect-manager.php
+++ b/inc/integrations/class-safe-redirect-manager.php
@@ -5,12 +5,31 @@
  * @package WP_Irving;
  */
 
-namespace WP_Irving;
+namespace WP_Irving\Integrations;
 
 /**
  * Class to parse redirects using the Safe Redirect Manager plugin.
  */
 class Safe_Redirect_Manager {
+
+	/**
+	 * Class instance.
+	 *
+	 * @var null|self
+	 */
+	protected static $instance;
+
+	/**
+	 * Get class instance.
+	 *
+	 * @return self
+	 */
+	public static function instance() {
+		if ( ! isset( static::$instance ) ) {
+			static::$instance = new static();
+		}
+		return static::$instance;
+	}
 
 	/**
 	 * Reference to Safe Redirect Manager SRM_Redirect singleton instance.
@@ -29,7 +48,7 @@ class Safe_Redirect_Manager {
 	/**
 	 * Constructor for class.
 	 */
-	public function __construct() {
+	public function setup() {
 		// Ensure Safe Redirect Manager exists and is enabled.
 		if ( ! class_exists( '\SRM_Redirect' ) || ! method_exists( '\SRM_Redirect', 'match_redirect' ) ) {
 			return;
@@ -90,10 +109,3 @@ class Safe_Redirect_Manager {
 		return $path;
 	}
 }
-
-add_action(
-	'init',
-	function() {
-		new \WP_Irving\Safe_Redirect_Manager();
-	}
-);

--- a/inc/integrations/class-vip-go.php
+++ b/inc/integrations/class-vip-go.php
@@ -5,7 +5,7 @@
  * @package WP_Irving;
  */
 
-namespace WP_Irving;
+namespace WP_Irving\Integrations;
 
 /**
  * Class to handle modifications specific to VIP Go.
@@ -13,9 +13,28 @@ namespace WP_Irving;
 class VIP_Go {
 
 	/**
+	 * Class instance.
+	 *
+	 * @var null|self
+	 */
+	protected static $instance;
+
+	/**
+	 * Get class instance.
+	 *
+	 * @return self
+	 */
+	public static function instance() {
+		if ( ! isset( static::$instance ) ) {
+			static::$instance = new static();
+		}
+		return static::$instance;
+	}
+
+	/**
 	 * Constructor for class.
 	 */
-	public function __construct() {
+	public function setup() {
 
 		if ( ! ( defined( 'WPCOM_IS_VIP_ENV' ) && WPCOM_IS_VIP_ENV ) ) {
 			return;
@@ -65,6 +84,6 @@ class VIP_Go {
 add_action(
 	'init',
 	function() {
-		new \WP_Irving\VIP_Go();
+		new \WP_Irving\Integrations\VIP_Go();
 	}
 );

--- a/inc/integrations/class-vip-go.php
+++ b/inc/integrations/class-vip-go.php
@@ -80,10 +80,3 @@ class VIP_Go {
 		return $purge_urls;
 	}
 }
-
-add_action(
-	'init',
-	function() {
-		new \WP_Irving\Integrations\VIP_Go();
-	}
-);

--- a/inc/integrations/class-wpcom-legacy-redirector.php
+++ b/inc/integrations/class-wpcom-legacy-redirector.php
@@ -7,7 +7,7 @@
  * @see https://github.com/Automattic/WPCOM-Legacy-Redirector
  */
 
-namespace WP_Irving;
+namespace WP_Irving\Integrations;
 
 use WPCOM_Legacy_Redirector as Legacy_Redirector;
 
@@ -17,9 +17,28 @@ use WPCOM_Legacy_Redirector as Legacy_Redirector;
 class WPCOM_Legacy_Redirector {
 
 	/**
+	 * Class instance.
+	 *
+	 * @var null|self
+	 */
+	protected static $instance;
+
+	/**
+	 * Get class instance.
+	 *
+	 * @return self
+	 */
+	public static function instance() {
+		if ( ! isset( static::$instance ) ) {
+			static::$instance = new static();
+		}
+		return static::$instance;
+	}
+
+	/**
 	 * Constructor for class.
 	 */
-	public function __construct() {
+	public function setup() {
 
 		// Ensure WPCOM Legacy Redirector exists and is enabled.
 		if (
@@ -92,10 +111,3 @@ class WPCOM_Legacy_Redirector {
 		return $data;
 	}
 }
-
-add_action(
-	'init',
-	function() {
-		new \WP_Irving\WPCOM_Legacy_Redirector();
-	}
-);

--- a/inc/integrations/class-yoast.php
+++ b/inc/integrations/class-yoast.php
@@ -5,7 +5,7 @@
  * @package WP_Irving
  */
 
-namespace WP_Irving;
+namespace WP_Irving\Integrations;
 
 use WP_Irving\Components;
 
@@ -15,9 +15,28 @@ use WP_Irving\Components;
 class Yoast {
 
 	/**
+	 * Class instance.
+	 *
+	 * @var null|self
+	 */
+	protected static $instance;
+
+	/**
+	 * Get class instance.
+	 *
+	 * @return self
+	 */
+	public static function instance() {
+		if ( ! isset( static::$instance ) ) {
+			static::$instance = new static();
+		}
+		return static::$instance;
+	}
+
+	/**
 	 * Constructor for class.
 	 */
-	public function __construct() {
+	public function setup() {
 
 		// Ensure Yoast exists and is enabled.
 		if ( ! class_exists( '\WPSEO_Frontend' ) ) {
@@ -65,10 +84,3 @@ class Yoast {
 		return ob_get_clean();
 	}
 }
-
-add_action(
-	'init',
-	function() {
-		new \WP_Irving\Yoast();
-	}
-);

--- a/inc/integrations/namespace.php
+++ b/inc/integrations/namespace.php
@@ -11,59 +11,67 @@ namespace WP_Irving\Integrations;
  * Hook namespace functionality.
  */
 function bootstrap() {
-    add_filter( 'init', __NAMESPACE__ . '\load_integrations_manager' );
-    add_filter( 'plugins_loaded', __NAMESPACE__ . '\auto_register_plugin_integrations' );
+	add_filter( 'init', __NAMESPACE__ . '\load_integrations_manager' );
+	add_filter( 'plugins_loaded', __NAMESPACE__ . '\auto_register_plugin_integrations' );
 }
 
+/**
+ * Load the integrations manager and register the base integrations.
+ */
 function load_integrations_manager() {
-    // Instantiate the integrations manager.
-    $manager = new \WP_Irving\Integrations\Integrations_Manager();
-    $manager->setup();
+	// Instantiate the integrations manager.
+	$manager = new \WP_Irving\Integrations\Integrations_Manager();
+	$manager->setup();
 
-    // Register integrations.
-    auto_register_integrations();
+	// Register integrations.
+	auto_register_integrations();
 }
 
 /**
  * Auto load the integrations.
  */
 function auto_register_integrations() {
-    $integrations = [
-        'archiveless'             => __NAMESPACE__ . '\Archiveless',
-        'google_analytics'        => __NAMESPACE__ . '\Google_Analytics',
-        'google_amp'              => __NAMESPACE__ . '\Google_AMP',
-        'new_relic'               => __NAMESPACE__ . '\New_Relic',
-        'pantheon'                => __NAMESPACE__ . '\Pantheon',
-        'safe_redirect_manager'   => __NAMESPACE__ . '\Safe_Redirect_Manager',
-        'vip_go'                  => __NAMESPACE__ . '\VIP_Go',
-        'wpcom_legacy_redirector' => __NAMESPACE__ . '\WPCOM_Legacy_Redirector',
-        'yoast'                   => __NAMESPACE__ . '\Yoast',
-    ];
+	$integrations = [
+		'archiveless'             => __NAMESPACE__ . '\Archiveless',
+		'google_analytics'        => __NAMESPACE__ . '\Google_Analytics',
+		'google_amp'              => __NAMESPACE__ . '\Google_AMP',
+		'new_relic'               => __NAMESPACE__ . '\New_Relic',
+		'pantheon'                => __NAMESPACE__ . '\Pantheon',
+		'safe_redirect_manager'   => __NAMESPACE__ . '\Safe_Redirect_Manager',
+		'vip_go'                  => __NAMESPACE__ . '\VIP_Go',
+		'wpcom_legacy_redirector' => __NAMESPACE__ . '\WPCOM_Legacy_Redirector',
+		'yoast'                   => __NAMESPACE__ . '\Yoast',
+	];
 
-    
-    // Allow new integrations to be added via a filter.
-    $integrations = apply_filters( 'wp_irving_active_integrations', $integrations );
-    
-    load_integrations( $integrations );
+	// Allow new integrations to be added via a filter.
+	$integrations = apply_filters( 'wp_irving_active_integrations', $integrations );
+
+	load_integrations( $integrations );
 }
 
 /**
  * Auto load the plugin-based integrations.
  */
 function auto_register_plugin_integrations() {
-    $integrations = [
-        'jwt_auth' => __NAMESPACE__ . '\JWT_Auth',
-    ];
+	$integrations = [
+		'jwt_auth' => __NAMESPACE__ . '\JWT_Auth',
+	];
 
-    // Allow new integrations to be added via a filter.
-    $integrations = apply_filters( 'wp_irving_active_plugin_integrations', $integrations );
+	// Allow new integrations to be added via a filter.
+	$integrations = apply_filters( 'wp_irving_active_plugin_integrations', $integrations );
 
-    load_integrations( $integrations );
+	load_integrations( $integrations );
 }
 
+/**
+ * Load the integrations provided by the autoload functions
+ * or via the active integrations filters.
+ *
+ * @param array $integrations The integrations to instantiate.
+ */
 function load_integrations( array $integrations ) {
-    foreach ( $integrations as $type => $class ) {
-        $integration = new $class();
-        $integration->setup();
-    }
+	foreach ( $integrations as $type => $class ) {
+		$integration = new $class();
+		$integration->setup();
+	}
 }

--- a/inc/integrations/namespace.php
+++ b/inc/integrations/namespace.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Integrations functionality.
+ *
+ * @package WP_Irving
+ */
+
+namespace WP_Irving\Integrations;
+
+/**
+ * Hook namespace functionality.
+ */
+function bootstrap() {
+    add_filter( 'init', __NAMESPACE__ . '\load_integrations_manager' );
+    add_filter( 'plugins_loaded', __NAMESPACE__ . '\auto_register_plugin_integrations' );
+}
+
+function load_integrations_manager() {
+    // Instantiate the integrations manager.
+    $manager = new \WP_Irving\Integrations\Integrations_Manager();
+    $manager->setup();
+
+    // Register integrations.
+    auto_register_integrations();
+}
+
+/**
+ * Auto load the integrations.
+ */
+function auto_register_integrations() {
+    $integrations = [
+        'archiveless'             => __NAMESPACE__ . '\Archiveless',
+        'google_analytics'        => __NAMESPACE__ . '\Google_Analytics',
+        'google_amp'              => __NAMESPACE__ . '\Google_AMP',
+        'new_relic'               => __NAMESPACE__ . '\New_Relic',
+        'pantheon'                => __NAMESPACE__ . '\Pantheon',
+        'safe_redirect_manager'   => __NAMESPACE__ . '\Safe_Redirect_Manager',
+        'vip_go'                  => __NAMESPACE__ . '\VIP_Go',
+        'wpcom_legacy_redirector' => __NAMESPACE__ . '\WPCOM_Legacy_Redirector',
+        'yoast'                   => __NAMESPACE__ . '\Yoast',
+    ];
+
+    
+    // Allow new integrations to be added via a filter.
+    $integrations = apply_filters( 'wp_irving_active_integrations', $integrations );
+    
+    load_integrations( $integrations );
+}
+
+/**
+ * Auto load the plugin-based integrations.
+ */
+function auto_register_plugin_integrations() {
+    $integrations = [
+        'jwt_auth' => __NAMESPACE__ . '\JWT_Auth',
+    ];
+
+    // Allow new integrations to be added via a filter.
+    $integrations = apply_filters( 'wp_irving_active_plugin_integrations', $integrations );
+
+    load_integrations( $integrations );
+}
+
+function load_integrations( array $integrations ) {
+    foreach ( $integrations as $type => $class ) {
+        $integration = new $class();
+        $integration->setup();
+    }
+}

--- a/inc/templates/namespace.php
+++ b/inc/templates/namespace.php
@@ -542,7 +542,7 @@ function setup_integrations( $data ) {
 		$config = [];
 		foreach ( $options as $option_key => $option_value ) {
 			if ( ! empty( $option_value ) ) {
-				$config[$option_key] = $option_value;
+				$config[ $option_key ] = $option_value;
 			}
 		}
 
@@ -555,7 +555,7 @@ function setup_integrations( $data ) {
 					[
 						'config' => [
 							'integrations' => $config,
-						]
+						],
 					]
 				)
 			);

--- a/inc/templates/namespace.php
+++ b/inc/templates/namespace.php
@@ -533,34 +533,38 @@ function setup_head(
  * @param array $data Data object to be hydrated by template.
  * @return array The update endpoint data.
  */
-function setup_integrations( $data ) {
+function setup_integrations( array $data ): array {
 	// Get any set integrations options.
 	$options = get_option( 'irving_integrations' );
 
 	// If options are present, append the integrations component into the endpoint response.
-	if ( ! empty( $options ) ) {
-		$config = [];
-		foreach ( $options as $option_key => $option_value ) {
-			if ( ! empty( $option_value ) ) {
-				$config[ $option_key ] = $option_value;
+	$options = array_filter(
+		$options,
+		function( $option ) {
+			foreach ( $option as $key => $value ) {
+				return ! empty( $value ) ?? [ $key => $value ];
 			}
-		}
+		},
+		ARRAY_FILTER_USE_BOTH
+	);
 
-		// Don't return an integrations config if no keys are present.
-		if ( ! empty( $config ) ) {
-			array_push(
-				$data['defaults'],
-				new Component(
-					'irving/integrations',
-					[
-						'config' => [
-							'integrations' => $config,
-						],
-					]
-				)
-			);
-		}
+	// Bail early if no options are present.
+	if ( empty( $options ) ) {
+		return $data;
 	}
+
+	// Don't return an integrations config if no keys are present.
+	array_push(
+		$data['defaults'],
+		new Component(
+			'irving/integrations',
+			[
+				'config' => [
+					'integrations' => $options,
+				],
+			]
+		)
+	);
 
 	return $data;
 }

--- a/inc/templates/namespace.php
+++ b/inc/templates/namespace.php
@@ -549,11 +549,15 @@ function setup_integrations( $data ) {
 		// Don't return an integrations config if no keys are present.
 		if ( ! empty( $config ) ) {
 			array_push(
-				$data['page'],
-				[
-					'name'   => 'irving/integrations',
-					'config' => $config,
-				]
+				$data['defaults'],
+				new Component(
+					'irving/integrations',
+					[
+						'config' => [
+							'integrations' => $config,
+						]
+					]
+				)
 			);
 		}
 	}

--- a/inc/templates/namespace.php
+++ b/inc/templates/namespace.php
@@ -537,6 +537,11 @@ function setup_integrations( array $data ): array {
 	// Get any set integrations options.
 	$options = get_option( 'irving_integrations' );
 
+	// Bail early if no options are present.
+	if ( empty( $options ) ) {
+		return $data;
+	}
+
 	// If options are present, append the integrations component into the endpoint response.
 	$options = array_filter(
 		$options,
@@ -547,23 +552,20 @@ function setup_integrations( array $data ): array {
 		}
 	);
 
-	// Bail early if no options are present.
-	if ( empty( $options ) ) {
-		return $data;
+	if ( ! empty( $options ) ) {
+		// Don't return an integrations config if no keys are present.
+		array_push(
+			$data['defaults'],
+			new Component(
+				'irving/integrations',
+				[
+					'config' => [
+						'integrations' => $options,
+					],
+				]
+			)
+		);
 	}
-
-	// Don't return an integrations config if no keys are present.
-	array_push(
-		$data['defaults'],
-		new Component(
-			'irving/integrations',
-			[
-				'config' => [
-					'integrations' => $options,
-				],
-			]
-		)
-	);
 
 	return $data;
 }

--- a/inc/templates/namespace.php
+++ b/inc/templates/namespace.php
@@ -539,15 +539,25 @@ function setup_integrations( $data ) {
 
 	// If options are present, append the integrations component into the endpoint response.
 	if ( ! empty( $options ) ) {
-		array_push(
-			$data['page'],
-			new Component(
-				'irving/integrations',
-				[
-					'config' => $options,
-				],
-			)
-		);
+		$config = [];
+		foreach ( $options as $option_key => $option_value ) {
+			if ( ! empty( $option_value ) ) {
+				$config[$option_key] = $option_value;
+			}
+		}
+
+		// Don't return an integrations config if no keys are present.
+		if ( ! empty( $config ) ) {
+			array_push(
+				$data['page'],
+				new Component(
+					'irving/integrations',
+					[
+						'config' => $config,
+					],
+				)
+			);
+		}
 	}
 
 	return $data;

--- a/inc/templates/namespace.php
+++ b/inc/templates/namespace.php
@@ -544,8 +544,7 @@ function setup_integrations( array $data ): array {
 			foreach ( $option as $key => $value ) {
 				return ! empty( $value ) ?? [ $key => $value ];
 			}
-		},
-		ARRAY_FILTER_USE_BOTH
+		}
 	);
 
 	// Bail early if no options are present.

--- a/inc/templates/namespace.php
+++ b/inc/templates/namespace.php
@@ -550,12 +550,10 @@ function setup_integrations( $data ) {
 		if ( ! empty( $config ) ) {
 			array_push(
 				$data['page'],
-				new Component(
-					'irving/integrations',
-					[
-						'config' => $config,
-					],
-				)
+				[
+					'name'   => 'irving/integrations',
+					'config' => $config,
+				]
 			);
 		}
 	}

--- a/inc/templates/namespace.php
+++ b/inc/templates/namespace.php
@@ -555,7 +555,7 @@ function setup_integrations( array $data ): array {
 	if ( ! empty( $options ) ) {
 		// Don't return an integrations config if no keys are present.
 		array_push(
-			$data['defaults'],
+			$data['page'],
 			new Component(
 				'irving/integrations',
 				[

--- a/inc/templates/namespace.php
+++ b/inc/templates/namespace.php
@@ -65,6 +65,9 @@ function load_template(
 	// Automatically setup the <Head> component.
 	$data = setup_head( $data, $query, $context, $path, $request );
 
+	// Automatically setup any active integrations.
+	$data = setup_integrations( $data );
+
 	// Setup a global style provider.
 	$data = setup_site_theme_provider( $data );
 
@@ -520,6 +523,32 @@ function setup_head(
 			]
 		)
 	);
+
+	return $data;
+}
+
+/**
+ * Manage any active integrations by inserting an `irving/integrations` component.
+ *
+ * @param array $data Data object to be hydrated by template.
+ * @return array The update endpoint data.
+ */
+function setup_integrations( $data ) {
+	// Get any set integrations options.
+	$options = get_option( 'irving_integrations' );
+
+	// If options are present, append the integrations component into the endpoint response.
+	if ( ! empty( $options ) ) {
+		array_push(
+			$data['page'],
+			new Component(
+				'irving/integrations',
+				[
+					'config' => $options,
+				],
+			)
+		);
+	}
 
 	return $data;
 }

--- a/wp-irving.php
+++ b/wp-irving.php
@@ -32,7 +32,6 @@ require_once WP_IRVING_PATH . '/inc/endpoints/class-form-endpoint.php';
 require_once WP_IRVING_PATH . '/inc/endpoints/class-cache-endpoint.php';
 
 // Integrations.
-require_once WP_IRVING_PATH . '/inc/integrations/class-integrations-manager.php';
 require_once WP_IRVING_PATH . '/inc/integrations/class-archiveless.php';
 require_once WP_IRVING_PATH . '/inc/integrations/class-google-amp.php';
 require_once WP_IRVING_PATH . '/inc/integrations/class-google-analytics.php';
@@ -43,6 +42,21 @@ require_once WP_IRVING_PATH . '/inc/integrations/class-vip-go.php';
 require_once WP_IRVING_PATH . '/inc/integrations/class-pantheon.php';
 require_once WP_IRVING_PATH . '/inc/integrations/class-wpcom-legacy-redirector.php';
 require_once WP_IRVING_PATH . '/inc/integrations/class-yoast.php';
+// Integrations Manager.
+require_once WP_IRVING_PATH . '/inc/integrations/class-integrations-manager.php';
+// Instantiate the integrations manager and the child integration's instances.
+add_action(
+    'init',
+    function() {
+        ( new \WP_Irving\Integrations\Integrations_Manager )::instance()->setup_integrations();
+    }
+);
+add_action(
+    'plugins_loaded',
+    function() {
+        ( new \WP_Irving\Integrations\Integrations_Manager )::instance()->setup_plugin_integrations();
+    }
+);
 
 // Replicating WP Core functionality.
 require_once WP_IRVING_PATH . '/inc/class-admin.php';

--- a/wp-irving.php
+++ b/wp-irving.php
@@ -45,17 +45,19 @@ require_once WP_IRVING_PATH . '/inc/integrations/class-yoast.php';
 // Integrations Manager.
 require_once WP_IRVING_PATH . '/inc/integrations/class-integrations-manager.php';
 // Instantiate the integrations manager and the child integration's instances.
+( new \WP_Irving\Integrations\Integrations_Manager )::instance();
+
 add_action(
-    'init',
-    function() {
-        ( ( new \WP_Irving\Integrations\Integrations_Manager )::instance()->setup_integrations() );
-    }
+	'init',
+	function() {
+		\WP_Irving\Integrations\Integrations_Manager::instance()->setup_integrations();
+	}
 );
 add_action(
-    'plugins_loaded',
-    function() {
-        ( ( new \WP_Irving\Integrations\Integrations_Manager )::instance()->setup_plugin_integrations() );
-    }
+	'plugins_loaded',
+	function() {
+		\WP_Irving\Integrations\Integrations_Manager::instance()->setup_plugin_integrations();
+	}
 );
 
 // Replicating WP Core functionality.

--- a/wp-irving.php
+++ b/wp-irving.php
@@ -46,16 +46,16 @@ require_once WP_IRVING_PATH . '/inc/integrations/class-yoast.php';
 require_once WP_IRVING_PATH . '/inc/integrations/class-integrations-manager.php';
 // Instantiate the integrations manager and the child integration's instances.
 add_action(
-    'init',
-    function() {
-        ( new \WP_Irving\Integrations\Integrations_Manager )::instance()->setup_integrations();
-    }
+	'init',
+	function() {
+		( ( new \WP_Irving\Integrations\Integrations_Manager )::instance() )->setup_integrations();
+	}
 );
 add_action(
-    'plugins_loaded',
-    function() {
-        ( new \WP_Irving\Integrations\Integrations_Manager )::instance()->setup_plugin_integrations();
-    }
+	'plugins_loaded',
+	function() {
+		( ( new \WP_Irving\Integrations\Integrations_Manager )::instance() )->setup_plugin_integrations();
+	}
 );
 
 // Replicating WP Core functionality.

--- a/wp-irving.php
+++ b/wp-irving.php
@@ -31,6 +31,9 @@ require_once WP_IRVING_PATH . '/inc/endpoints/class-data-endpoint.php';
 require_once WP_IRVING_PATH . '/inc/endpoints/class-form-endpoint.php';
 require_once WP_IRVING_PATH . '/inc/endpoints/class-cache-endpoint.php';
 
+// Integrations manager.
+require_once WP_IRVING_PATH . '/inc/class-integrations.php';
+
 // Integrations.
 require_once WP_IRVING_PATH . '/inc/integrations/class-archiveless.php';
 require_once WP_IRVING_PATH . '/inc/integrations/class-google-amp.php';

--- a/wp-irving.php
+++ b/wp-irving.php
@@ -46,16 +46,16 @@ require_once WP_IRVING_PATH . '/inc/integrations/class-yoast.php';
 require_once WP_IRVING_PATH . '/inc/integrations/class-integrations-manager.php';
 // Instantiate the integrations manager and the child integration's instances.
 add_action(
-	'init',
-	function() {
-		( ( new \WP_Irving\Integrations\Integrations_Manager )::instance() )->setup_integrations();
-	}
+    'init',
+    function() {
+        ( ( new \WP_Irving\Integrations\Integrations_Manager )::instance()->setup_integrations() );
+    }
 );
 add_action(
-	'plugins_loaded',
-	function() {
-		( ( new \WP_Irving\Integrations\Integrations_Manager )::instance() )->setup_plugin_integrations();
-	}
+    'plugins_loaded',
+    function() {
+        ( ( new \WP_Irving\Integrations\Integrations_Manager )::instance()->setup_plugin_integrations() );
+    }
 );
 
 // Replicating WP Core functionality.

--- a/wp-irving.php
+++ b/wp-irving.php
@@ -42,24 +42,8 @@ require_once WP_IRVING_PATH . '/inc/integrations/class-vip-go.php';
 require_once WP_IRVING_PATH . '/inc/integrations/class-pantheon.php';
 require_once WP_IRVING_PATH . '/inc/integrations/class-wpcom-legacy-redirector.php';
 require_once WP_IRVING_PATH . '/inc/integrations/class-yoast.php';
-// Integrations Manager.
 require_once WP_IRVING_PATH . '/inc/integrations/class-integrations-manager.php';
-// Instantiate the integrations manager.
-new \WP_Irving\Integrations\Integrations_Manager();
-// Setup child integrations on `init`.
-add_action(
-	'init',
-	function() {
-		\WP_Irving\Integrations\Integrations_Manager::instance()->setup_integrations();
-	}
-);
-// Setup child plugin integrations on `plugins_loaded`.
-add_action(
-	'plugins_loaded',
-	function() {
-		\WP_Irving\Integrations\Integrations_Manager::instance()->setup_plugin_integrations();
-	}
-);
+require_once WP_IRVING_PATH . '/inc/integrations/namespace.php';
 
 // Replicating WP Core functionality.
 require_once WP_IRVING_PATH . '/inc/class-admin.php';
@@ -96,3 +80,4 @@ new REST_API\Cache_Endpoint();
 // Bootstrap functionality.
 Components\bootstrap();
 Templates\bootstrap();
+Integrations\bootstrap();

--- a/wp-irving.php
+++ b/wp-irving.php
@@ -31,12 +31,11 @@ require_once WP_IRVING_PATH . '/inc/endpoints/class-data-endpoint.php';
 require_once WP_IRVING_PATH . '/inc/endpoints/class-form-endpoint.php';
 require_once WP_IRVING_PATH . '/inc/endpoints/class-cache-endpoint.php';
 
-// Integrations manager.
-require_once WP_IRVING_PATH . '/inc/class-integrations.php';
-
 // Integrations.
+require_once WP_IRVING_PATH . '/inc/integrations/class-integrations-manager.php';
 require_once WP_IRVING_PATH . '/inc/integrations/class-archiveless.php';
 require_once WP_IRVING_PATH . '/inc/integrations/class-google-amp.php';
+require_once WP_IRVING_PATH . '/inc/integrations/class-google-analytics.php';
 require_once WP_IRVING_PATH . '/inc/integrations/class-jwt-auth.php';
 require_once WP_IRVING_PATH . '/inc/integrations/class-new-relic.php';
 require_once WP_IRVING_PATH . '/inc/integrations/class-safe-redirect-manager.php';

--- a/wp-irving.php
+++ b/wp-irving.php
@@ -44,15 +44,16 @@ require_once WP_IRVING_PATH . '/inc/integrations/class-wpcom-legacy-redirector.p
 require_once WP_IRVING_PATH . '/inc/integrations/class-yoast.php';
 // Integrations Manager.
 require_once WP_IRVING_PATH . '/inc/integrations/class-integrations-manager.php';
-// Instantiate the integrations manager and the child integration's instances.
-( new \WP_Irving\Integrations\Integrations_Manager )::instance();
-
+// Instantiate the integrations manager.
+new \WP_Irving\Integrations\Integrations_Manager;
+// Setup child integrations on `init`.
 add_action(
 	'init',
 	function() {
 		\WP_Irving\Integrations\Integrations_Manager::instance()->setup_integrations();
 	}
 );
+// Setup child plugin integrations on `plugins_loaded`.
 add_action(
 	'plugins_loaded',
 	function() {

--- a/wp-irving.php
+++ b/wp-irving.php
@@ -45,7 +45,7 @@ require_once WP_IRVING_PATH . '/inc/integrations/class-yoast.php';
 // Integrations Manager.
 require_once WP_IRVING_PATH . '/inc/integrations/class-integrations-manager.php';
 // Instantiate the integrations manager.
-new \WP_Irving\Integrations\Integrations_Manager;
+new \WP_Irving\Integrations\Integrations_Manager();
 // Setup child integrations on `init`.
 add_action(
 	'init',


### PR DESCRIPTION
**Important:** This PR should be reviewed in tandem with alleyinteractive/irving#258, as it includes core functionality on the React side that is required for this work to insert configured integrations into the DOM.

This PR is for the back-end work outlined in [IRV-592](https://alleyinteractive.atlassian.net/browse/IRV-592), which includes the creation and configuration of the "Irving Integrations" WP settings page, the creation of the `Google_Analytics` integration and the addition of the Tracking ID settings field to the integrations settings page, and the addition of the `irving/integrations` object in the Irving REST API to pass any configured fields to the integrations manager component on the front-end.