### PR TITLE
Ensure all endpoints have a permissions callback

### DIFF
--- a/inc/endpoints/class-cache-endpoint.php
+++ b/inc/endpoints/class-cache-endpoint.php
@@ -50,8 +50,8 @@ class Cache_Endpoint extends Endpoint {
 		/**
 		 * Filter the permissions check.
 		 *
-		 * @param bool|\WP_Error   $retval  Returned value.
-		 * @param WP_REST_Request $request The request sent to the API.
+		 * @param bool|callable   $permission_callback Filtered `permission_callback` value.
+		 * @param WP_REST_Request $request             Endpoint request.
 		 */
 		return apply_filters( 'wp_irving_cache_endpoint_permissions_check', current_user_can( 'manage_options' ), $request );
 	}

--- a/inc/endpoints/class-cache-endpoint.php
+++ b/inc/endpoints/class-cache-endpoint.php
@@ -32,8 +32,9 @@ class Cache_Endpoint extends Endpoint {
 			self::get_namespace(),
 			'/purge-cache',
 			[
-				'methods'  => \WP_REST_Server::CREATABLE,
-				'callback' => [ $this, 'get_route_response' ],
+				'callback'            => [ $this, 'get_route_response' ],
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'permission_callback' => '__return_true',
 			]
 		);
 	}

--- a/inc/endpoints/class-cache-endpoint.php
+++ b/inc/endpoints/class-cache-endpoint.php
@@ -34,9 +34,26 @@ class Cache_Endpoint extends Endpoint {
 			[
 				'callback'            => [ $this, 'get_route_response' ],
 				'methods'             => \WP_REST_Server::CREATABLE,
-				'permission_callback' => '__return_true',
+				'permission_callback' => [ $this, 'permissions_check' ],
 			]
 		);
+	}
+
+	/**
+	 * Permissions check.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return bool|\WP_Error
+	 */
+	public function permissions_check( $request ) {
+
+		/**
+		 * Filter the permissions check.
+		 *
+		 * @param bool|\WP_Error   $retval  Returned value.
+		 * @param WP_REST_Request $request The request sent to the API.
+		 */
+		return apply_filters( 'wp_irving_cache_endpoint_permissions_check', current_user_can( 'manage_options' ), $request );
 	}
 
 	/**

--- a/inc/endpoints/class-components-endpoint.php
+++ b/inc/endpoints/class-components-endpoint.php
@@ -95,8 +95,8 @@ class Components_Endpoint extends Endpoint {
 			self::get_namespace(),
 			'/components/',
 			[
-				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_route_response' ],
+				'methods'             => \WP_REST_Server::READABLE,
 				'permission_callback' => [ $this, 'permissions_check' ],
 			]
 		);

--- a/inc/endpoints/class-components-registry-endpoint.php
+++ b/inc/endpoints/class-components-registry-endpoint.php
@@ -23,10 +23,11 @@ class Components_Registry_Endpoint extends Endpoint {
 			self::get_namespace(),
 			'/registered-components/',
 			[
-				'methods'  => \WP_REST_Server::READABLE,
-				'callback' => function() {
+				'callback'            => function() {
 					return Components\get_registry()->get_registered_components();
 				},
+				'methods'             => \WP_REST_Server::READABLE,
+				'permission_callback' => '__return_true',
 			]
 		);
 	}

--- a/inc/endpoints/class-data-endpoint.php
+++ b/inc/endpoints/class-data-endpoint.php
@@ -48,7 +48,7 @@ class Data_Endpoint extends Endpoint {
 				[
 					'callback'            => $endpoint['callback'],
 					'methods'             => \WP_REST_Server::READABLE,
-					'permission_callback' => '__return_true',
+					'permission_callback' => $endpoint['permission_callback'] ?? '__return_true',
 				]
 			);
 		}

--- a/inc/endpoints/class-data-endpoint.php
+++ b/inc/endpoints/class-data-endpoint.php
@@ -31,8 +31,9 @@ class Data_Endpoint extends Endpoint {
 		 * @param array $data_endpoints {
 		 *     Data endpoint slugs and callback functions.
 		 *
-		 *     @type string   $slug     The slug for the data endpoint.
-		 *     @type callable $callback Response callback to use when the endpoint is called.
+		 *     @type string   $slug                The slug for the data endpoint.
+		 *     @type callable $callback            Response callback to use when the endpoint is called.
+		 *     @type callable $permission_callback Permission callback to use when the endpoint is called.
 		 * }
 		 */
 		$data_endpoints = (array) apply_filters( 'wp_irving_data_endpoints', [] );
@@ -41,16 +42,29 @@ class Data_Endpoint extends Endpoint {
 			return;
 		}
 
-		foreach ( $data_endpoints as $endpoint ) {
-			register_rest_route(
-				self::get_namespace(),
-				'/data/' . $endpoint['slug'],
+		// Register each endpoint.
+		foreach ( $data_endpoints as $args ) {
+
+			$args = wp_parse_args(
+				$args,
 				[
-					'callback'            => $endpoint['callback'],
+					'callback'            => '__return_true',
 					'methods'             => \WP_REST_Server::READABLE,
-					'permission_callback' => $endpoint['permission_callback'] ?? '__return_true',
+					'permission_callback' => '__return_true',
+					'slug'                => '',
 				]
 			);
+
+			// Ensure we have a slug.
+			if ( empty( $args['slug'] ) || ! is_string( $args['slug'] ) ) {
+				break;
+			}
+
+			// Build the route, and unset the slug.
+			$route = '/data/' . $args['slug'];
+			unset($args['slug']);
+
+			register_rest_route( self::get_namespace(), $route, $args );
 		}
 	}
 }

--- a/inc/endpoints/class-data-endpoint.php
+++ b/inc/endpoints/class-data-endpoint.php
@@ -46,8 +46,9 @@ class Data_Endpoint extends Endpoint {
 				self::get_namespace(),
 				'/data/' . $endpoint['slug'],
 				[
-					'methods'  => \WP_REST_Server::READABLE,
-					'callback' => $endpoint['callback'],
+					'callback'            => $endpoint['callback'],
+					'methods'             => \WP_REST_Server::READABLE,
+					'permission_callback' => '__return_true',
 				]
 			);
 		}

--- a/inc/endpoints/class-data-endpoint.php
+++ b/inc/endpoints/class-data-endpoint.php
@@ -62,7 +62,7 @@ class Data_Endpoint extends Endpoint {
 
 			// Build the route, and unset the slug.
 			$route = '/data/' . $args['slug'];
-			unset($args['slug']);
+			unset( $args['slug'] );
 
 			register_rest_route( self::get_namespace(), $route, $args );
 		}

--- a/inc/endpoints/class-data-endpoint.php
+++ b/inc/endpoints/class-data-endpoint.php
@@ -57,7 +57,7 @@ class Data_Endpoint extends Endpoint {
 
 			// Ensure we have a slug.
 			if ( empty( $args['slug'] ) || ! is_string( $args['slug'] ) ) {
-				break;
+				continue;
 			}
 
 			// Build the route, and unset the slug.

--- a/inc/endpoints/class-form-endpoint.php
+++ b/inc/endpoints/class-form-endpoint.php
@@ -46,8 +46,9 @@ class Form_Endpoint extends Endpoint {
 				self::get_namespace(),
 				'/form/' . $endpoint['slug'],
 				[
-					'methods'  => \WP_REST_Server::CREATABLE,
-					'callback' => $endpoint['callback'],
+					'callback'            => $endpoint['callback'],
+					'methods'             => \WP_REST_Server::CREATABLE,
+					'permission_callback' => '__return_true',
 				]
 			);
 		}

--- a/tests/endpoints/test-class-cache-endpoint.php
+++ b/tests/endpoints/test-class-cache-endpoint.php
@@ -78,9 +78,11 @@ class Test_Class_Cache_Endpoint extends WP_UnitTestCase {
 		);
 
 		// Create and get a user with the administrator role.
-		$administrator = $this->factory->user->create_and_get();
-		$administrator->add_role( 'administrator' );
-		$administrator->remove_role( 'subscriber' );
+		$administrator = $this->factory->user->create_and_get(
+			[
+				'role' => 'administrator',
+			]
+		);
 		wp_set_current_user( $administrator->ID );
 
 		$this->assertEquals(

--- a/tests/endpoints/test-class-cache-endpoint.php
+++ b/tests/endpoints/test-class-cache-endpoint.php
@@ -28,7 +28,7 @@ class Test_Class_Cache_Endpoint extends WP_UnitTestCase {
 	public function create_rest_request( $params = [] ): WP_REST_REQUEST {
 
 		// Build the cache endpoint url.
-		$endpoint_url = 'http://' . WP_TESTS_DOMAIN . '/wp-json/irving/v1/purge-cache/';
+		$endpoint_url = 'irving/v1/purge-cache/';
 
 		// Endpoint parameters.
 		$params = wp_parse_args(

--- a/tests/endpoints/test-class-cache-endpoint.php
+++ b/tests/endpoints/test-class-cache-endpoint.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Class Test_Class_Cache_Endpoint.
+ *
+ * @package WP_Irving
+ */
+
+namespace WP_Irving;
+
+use WP_Irving\REST_API;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_UnitTestCase;
+
+/**
+ * Test the cache endpoint functionality.
+ *
+ * @group endpoints
+ */
+class Test_Class_Cache_Endpoint extends WP_UnitTestCase {
+
+	/**
+	 * Create an instance of WP_REST_Request class with a given path.
+	 *
+	 * @param array $params Endpoint parameters.
+	 * @return WP_REST_Request
+	 */
+	public function create_rest_request( $params = [] ): WP_REST_REQUEST {
+
+		// Build the `purge-cache` endpoint url.
+		$endpoint_url = 'http://' . WP_TESTS_DOMAIN . '/wp-json/irving/v1/purge-cache/';
+
+		// Endpoint parameters
+		$params = wp_parse_args(
+			$params,
+			[
+				'action' => 'irving_page_cache_purge',
+				'route'  => '/',
+			]
+		);
+
+		// Build full url and do a POST request.
+		$request  = new WP_REST_Request( 'POST', $endpoint_url,  );
+		$request->set_body_params( $params );
+
+		return $request;
+	}
+
+	/**
+	 * Get the response from a hit on the cache endpoint.
+	 *
+	 * @param array $params Endpoint parameters.
+	 * @return WP_REST_Response
+	 */
+	public function get_cache_endpoint_response( array $params = [] ): WP_REST_Response {
+		return ( new REST_API\Cache_Endpoint() )
+			->get_route_response(
+				$this->create_rest_request( $params )
+			);
+	}
+
+	/**
+	 * Test the permissions callback using user roles.
+	 */
+	public function test_permission_check_with_roles() {
+
+		// Get an instance of the endpoint.
+		$endpoint = new REST_API\Cache_Endpoint();
+
+		// Create and get a user with the subscriber role.
+		$subscriber    = $this->factory->user->create_and_get();
+		wp_set_current_user( $subscriber->ID );
+
+		$this->assertEquals(
+			false,
+			$endpoint->permissions_check( $this->get_cache_endpoint_response() ),
+			'Permission check for subscriber should have failed.'
+		);
+
+		// Create and get a user with the administrator role.
+		$administrator = $this->factory->user->create_and_get();
+		$administrator->add_role( 'administrator' );
+		$administrator->remove_role( 'subscriber' );
+		wp_set_current_user( $administrator->ID );
+
+		$this->assertEquals(
+			true,
+			$endpoint->permissions_check( $this->get_cache_endpoint_response() ),
+			'Permission check for administrator should have passed.'
+		);
+	}
+
+	/**
+	 * Test the permissions callback using the filter.
+	 */
+	public function test_permission_check_with_filter() {
+
+		// Get an instance of the endpoint.
+		$endpoint = new REST_API\Cache_Endpoint();
+
+		add_filter( 'wp_irving_cache_endpoint_permissions_check', '__return_false' );
+
+		$this->assertEquals(
+			false,
+			$endpoint->permissions_check( $this->get_cache_endpoint_response() ),
+			'Permission check for filtered value should have failed.'
+		);
+
+		add_filter( 'wp_irving_cache_endpoint_permissions_check', '__return_true' );
+
+		$this->assertEquals(
+			true,
+			$endpoint->permissions_check( $this->get_cache_endpoint_response() ),
+			'Permission check for filtered value should have passed.'
+		);
+	}
+}

--- a/tests/endpoints/test-class-cache-endpoint.php
+++ b/tests/endpoints/test-class-cache-endpoint.php
@@ -27,7 +27,7 @@ class Test_Class_Cache_Endpoint extends WP_UnitTestCase {
 	 */
 	public function create_rest_request( $params = [] ): WP_REST_REQUEST {
 
-		// Build the `purge-cache` endpoint url.
+		// Build the cache endpoint url.
 		$endpoint_url = 'http://' . WP_TESTS_DOMAIN . '/wp-json/irving/v1/purge-cache/';
 
 		// Endpoint parameters

--- a/tests/endpoints/test-class-cache-endpoint.php
+++ b/tests/endpoints/test-class-cache-endpoint.php
@@ -30,7 +30,7 @@ class Test_Class_Cache_Endpoint extends WP_UnitTestCase {
 		// Build the cache endpoint url.
 		$endpoint_url = 'http://' . WP_TESTS_DOMAIN . '/wp-json/irving/v1/purge-cache/';
 
-		// Endpoint parameters
+		// Endpoint parameters.
 		$params = wp_parse_args(
 			$params,
 			[
@@ -40,7 +40,7 @@ class Test_Class_Cache_Endpoint extends WP_UnitTestCase {
 		);
 
 		// Build full url and do a POST request.
-		$request  = new WP_REST_Request( 'POST', $endpoint_url,  );
+		$request = new WP_REST_Request( 'POST', $endpoint_url );
 		$request->set_body_params( $params );
 
 		return $request;
@@ -68,7 +68,7 @@ class Test_Class_Cache_Endpoint extends WP_UnitTestCase {
 		$endpoint = new REST_API\Cache_Endpoint();
 
 		// Create and get a user with the subscriber role.
-		$subscriber    = $this->factory->user->create_and_get();
+		$subscriber = $this->factory->user->create_and_get();
 		wp_set_current_user( $subscriber->ID );
 
 		$this->assertEquals(

--- a/tests/endpoints/test-class-data-endpoint.php
+++ b/tests/endpoints/test-class-data-endpoint.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Class Test_Class_Data_Endpoint.
+ *
+ * @package WP_Irving
+ */
+
+namespace WP_Irving;
+
+use WP_Irving\REST_API;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_Error;
+use WP_UnitTestCase;
+
+/**
+ * Test the data endpoint functionality.
+ *
+ * @group endpoints
+ */
+class Test_Class_Data_Endpoint extends WP_UnitTestCase {
+
+	/**
+	 * Class setup.
+	 */
+	public static function wpSetUpBeforeClass() {
+		add_filter(
+			'wp_irving_data_endpoints',
+			function( $data ) {
+				return [
+					[
+						'slug'                => 'return-true',
+						'callback'            => function() {
+							return [ 'Hello World' ];
+						},
+					],
+					[
+						'slug'                => 'fail-permissions-check',
+						'callback'            => '__return_true',
+						'permission_callback' => '__return_false',
+					],
+				];
+			}
+		);
+	}
+
+	/**
+	 * Create an instance of WP_REST_Request class with a given path.
+	 *
+	 * @param string $data_slug Slug of the data endpoint.
+	 * @return WP_REST_Request
+	 */
+	public function create_data_endpoint_rest_request( string $data_slug ): WP_REST_Request {
+		return new WP_REST_Request( 'GET', '/irving/v1/data/' . $data_slug );
+	}
+
+	/**
+	 * Get the response from a hit on the data endpoint.
+	 *
+	 * @param string $data_slug Slug of the data endpoint.
+	 * @return array
+	 */
+	public function get_data_endpoint_response( string $data_slug ): array {
+		return rest_do_request( $this->create_data_endpoint_rest_request( $data_slug ) )->get_data();
+	}
+
+	/**
+	 * Test the `permission_callback` for the data endpoint.
+	 */
+	public function test_permission_callback() {
+		$this->assertEquals(
+			[
+				'Hello World',
+			],
+			$this->get_data_endpoint_response( 'return-true' ),
+			'Endpoint did not return the right data.'
+		);
+
+		$this->assertEquals(
+			[
+				'code'    => 'rest_forbidden',
+				'message' => 'Sorry, you are not allowed to do that.',
+				'data'    => [
+					'status' => '401',
+				],
+			],
+			$this->get_data_endpoint_response( 'fail-permissions-check' ),
+			'Permissions check did not fail.'
+		);
+	}
+}

--- a/tests/endpoints/test-class-data-endpoint.php
+++ b/tests/endpoints/test-class-data-endpoint.php
@@ -29,8 +29,8 @@ class Test_Class_Data_Endpoint extends WP_UnitTestCase {
 			function( $data ) {
 				return [
 					[
-						'slug'                => 'return-true',
-						'callback'            => function() {
+						'slug'     => 'return-true',
+						'callback' => function() {
 							return [ 'Hello World' ];
 						},
 					],

--- a/tests/endpoints/test-class-data-endpoint.php
+++ b/tests/endpoints/test-class-data-endpoint.php
@@ -21,9 +21,11 @@ use WP_UnitTestCase;
 class Test_Class_Data_Endpoint extends WP_UnitTestCase {
 
 	/**
-	 * Class setup.
+	 * Setup.
 	 */
-	public static function wpSetUpBeforeClass() {
+	public function setUp() {
+		parent::setup();
+
 		add_filter(
 			'wp_irving_data_endpoints',
 			function( $data ) {


### PR DESCRIPTION
WordPress 5.5 will start triggering `_doing_it_wrong` errors for any REST endpoints that don't set a permission_callback. See: https://make.wordpress.org/core/2020/07/22/rest-api-changes-in-wordpress-5-5/

To avoid these errors, we need to ensure all registered routes in the plugin include a permissions callback when registering the route.