### PR TITLE
IRV-617: Implement Term Components

### DIFF
--- a/inc/components/components/term-link/component.json
+++ b/inc/components/components/term-link/component.json
@@ -1,0 +1,26 @@
+{
+  "name": "irving/term-link",
+  "_alias": "irving/link",
+  "description": "Get the term link.",
+  "config": {
+    "href": {
+      "default": "",
+      "type": "string"
+    },
+    "rel": {
+      "default": "",
+      "type": "string"
+    },
+    "style": {
+      "default": [],
+      "type": "array"
+    },
+    "target": {
+      "default": "",
+      "type": "string"
+    }
+  },
+  "use_context": {
+    "irving/term_id": "term_id"
+  }
+}

--- a/inc/components/components/term-link/component.php
+++ b/inc/components/components/term-link/component.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Term link.
+ *
+ * Get the term link.
+ *
+ * @package WP_Irving
+ */
+
+namespace WP_Irving\Components;
+
+/**
+ * Register the component and callback.
+ */
+register_component_from_config(
+	__DIR__ . '/component',
+	[
+		'config_callback' => function ( array $config ): array {
+			$term_id = $config['term_id'] ?? 0;
+
+			// Bail early if we have no term ID.
+			if ( ! $term_id ) {
+				return $config;
+			}
+			echo 'yo'; die();
+
+			$link = get_term_link( $term_id );
+
+			// Bail if we have no link.
+			if ( is_wp_error( $link ) ) {
+				return $config;
+			}
+
+			return array_merge(
+				$config,
+				[
+					'href' => $link,
+				]
+			);
+		},
+	]
+);

--- a/inc/components/components/term-link/component.php
+++ b/inc/components/components/term-link/component.php
@@ -22,9 +22,8 @@ register_component_from_config(
 			if ( ! $term_id ) {
 				return $config;
 			}
-			echo 'yo'; die();
 
-			$link = get_term_link( $term_id );
+			$link = get_term_link( (int) $term_id );
 
 			// Bail if we have no link.
 			if ( is_wp_error( $link ) ) {

--- a/inc/components/components/term-name/component.json
+++ b/inc/components/components/term-name/component.json
@@ -1,0 +1,9 @@
+{
+  "name": "irving/term-name",
+  "_alias": "irving/text",
+  "category": "Term",
+  "description": "Get the term name.",
+  "use_context": {
+    "irving/term_id": "term_id"
+  }
+}

--- a/inc/components/components/term-name/component.php
+++ b/inc/components/components/term-name/component.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Term name.
+ *
+ * Get the term name.
+ *
+ * @package WP_Irving
+ */
+
+namespace WP_Irving\Components;
+
+use WP_Term;
+
+/**
+ * Register the component and callback.
+ */
+register_component_from_config(
+	__DIR__ . '/component',
+	[
+		'config_callback' => function ( array $config ): array {
+
+			// Term ID is set via context and should always have a value.
+			$term = get_term( $config['term_id'] ?? 0 );
+
+			// Bail if the term is invalid.
+			if ( is_wp_error( $term ) || ! $term instanceof WP_Term ) {
+				return $config;
+			}
+
+			$config['content'] = html_entity_decode( $term->name, ENT_QUOTES, get_bloginfo( 'charset' ) );
+
+			return $config;
+		},
+	]
+);

--- a/inc/components/components/term-provider/component.json
+++ b/inc/components/components/term-provider/component.json
@@ -13,6 +13,6 @@
     "irving/term_id": "term_id"
   },
   "use_context": {
-    "irving/post_meta": "term_id"
+    "irving/term_id": "term_id"
   }
 }

--- a/inc/components/components/term-provider/component.json
+++ b/inc/components/components/term-provider/component.json
@@ -1,0 +1,18 @@
+{
+  "name": "irving/term-provider",
+  "_alias": "irving/fragment",
+  "category": "Term",
+  "description": "Term context provider.",
+  "config": {
+    "term_id": {
+      "default": 0,
+      "type": "integer"
+    }
+  },
+  "provides_context": {
+    "irving/term_id": "term_id"
+  },
+  "use_context": {
+    "irving/post_meta": "term_id"
+  }
+}

--- a/inc/components/components/term-provider/component.php
+++ b/inc/components/components/term-provider/component.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Term provider.
+ *
+ * Provide term context to children components.
+ *
+ * @package WP_Irving
+ */
+
+namespace WP_Irving\Components;
+
+/**
+ * Register the component.
+ */
+register_component_from_config( __DIR__ . '/component' );

--- a/inc/components/namespace.php
+++ b/inc/components/namespace.php
@@ -46,6 +46,7 @@ function get_context_store(): Context_Store {
 			[
 				'irving/post_id'  => get_the_ID(),
 				'irving/wp_query' => $wp_query,
+				'irving/term_id'  => ( $wp_query->get_queried_object() instanceof \WP_Term ) ? $wp_query->get_queried_object_id() : null,
 			]
 		);
 	}

--- a/tests/components/test-components.php
+++ b/tests/components/test-components.php
@@ -138,6 +138,15 @@ class Test_Components extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Helper to get the term object
+	 *
+	 * @return WP_Term Term object.
+	 */
+	public function get_term() {
+		return get_term( self::$term_id );
+	}
+
+	/**
 	 * Set up shared fixtures.
 	 *
 	 * @param WP_UnitTest_Factory $factory Factory instance.
@@ -170,12 +179,12 @@ class Test_Components extends WP_UnitTestCase {
 			]
 		);
 
-		// self::$term_id = $factory->term->create(
-		// 	[
-		// 		'name'     => 'Example Category',
-		// 		'taxonomy' => 'category',
-		// 	]
-		// );
+		self::$term_id = $factory->term->create(
+			[
+				'name'     => 'Example Category',
+				'taxonomy' => 'category',
+			]
+		);
 
 	}
 
@@ -1199,6 +1208,57 @@ class Test_Components extends WP_UnitTestCase {
 
 		// Cleanup.
 		unregister_component( 'example/use-context' );
+
+		$this->assertComponentEquals( $expected, $component );
+	}
+
+	/**
+	 * Test irving/term-name component.
+	 *
+	 * @group core-components
+	 */
+	public function test_component_term_name() {
+		$this->go_to( '?taxonomy=category&term=' . $this->get_term()->slug );
+
+		$expected = $this->get_expected_component(
+			'irving/term-name',
+			[
+				'_alias'   => 'irving/text',
+				'config'   => [
+					'content' => $this->get_term()->name,
+					'termId'  => $this->get_term_id(),
+				],
+			]
+		);
+
+		$component = new Component( 'irving/term-name' );
+
+		$this->assertComponentEquals( $expected, $component );
+	}
+
+	/**
+	 * Test irving/term-link component.
+	 *
+	 * @group core-components
+	 */
+	public function test_component_term_link() {
+		$this->go_to( '?taxonomy=category&term=' . $this->get_term()->slug );
+
+		$expected = $this->get_expected_component(
+			'irving/term-link',
+			[
+				'_alias' => 'irving/link',
+				'config' => [
+					'href'   => get_term_link( (int) $this->get_term_id() ),
+					'rel'    => '',
+					'style'  => [],
+					'target' => '',
+					'termId' => $this->get_term_id(),
+				],
+			]
+		);
+
+		$component = new Component( 'irving/term-link' );
 
 		$this->assertComponentEquals( $expected, $component );
 	}

--- a/tests/components/test-components.php
+++ b/tests/components/test-components.php
@@ -1223,8 +1223,8 @@ class Test_Components extends WP_UnitTestCase {
 		$expected = $this->get_expected_component(
 			'irving/term-name',
 			[
-				'_alias'   => 'irving/text',
-				'config'   => [
+				'_alias' => 'irving/text',
+				'config' => [
 					'content' => $this->get_term()->name,
 					'termId'  => $this->get_term_id(),
 				],

--- a/tests/components/test-components.php
+++ b/tests/components/test-components.php
@@ -228,7 +228,7 @@ class Test_Components extends WP_UnitTestCase {
 	 * @group context
 	 */
 	public function test_template_default_context() {
-		// Override the global post object for this test.
+		// Override the global post and wp_query objects for this test.
 		global $post;
 
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
@@ -238,7 +238,21 @@ class Test_Components extends WP_UnitTestCase {
 
 		// Test initial context.
 		$this->assertEquals( $post->ID, $context->get( 'irving/post_id' ), 'Default post ID context not set.' );
+		$this->assertNull( $context->get( 'irving/term_id' ), 'Default term ID context not set.' );
 		$this->assertEquals( new WP_Query( [] ), $context->get( 'irving/wp_query' ), 'Default wp query context not set.' );
+	}
+
+	/**
+	 * Test default template context on a category archive.
+	 *
+	 * @group context
+	 */
+	public function test_template_default_context_on_category_archive() {
+		$this->go_to( '?taxonomy=category&term=' . $this->get_term()->slug );
+
+		$context = get_context_store();
+
+		$this->assertEquals( $this->get_term_id(), $context->get( 'irving/term_id' ), 'Default term ID context not set.' );
 	}
 
 	/**

--- a/tests/components/test-components.php
+++ b/tests/components/test-components.php
@@ -40,6 +40,13 @@ class Test_Components extends WP_UnitTestCase {
 	public static $post_id;
 
 	/**
+	 * Test term.
+	 *
+	 * @var int Term ID.
+	 */
+	public static $term_id;
+
+	/**
 	 * Helper to get the author ID.
 	 *
 	 * @return int Author ID.
@@ -122,6 +129,15 @@ class Test_Components extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Helper to get the term ID.
+	 *
+	 * @return int Term ID.
+	 */
+	public function get_term_id() {
+		return self::$term_id;
+	}
+
+	/**
 	 * Set up shared fixtures.
 	 *
 	 * @param WP_UnitTest_Factory $factory Factory instance.
@@ -153,6 +169,13 @@ class Test_Components extends WP_UnitTestCase {
 				'_thumbnail_id' => self::$attachment_id,
 			]
 		);
+
+		// self::$term_id = $factory->term->create(
+		// 	[
+		// 		'name'     => 'Example Category',
+		// 		'taxonomy' => 'category',
+		// 	]
+		// );
 
 	}
 
@@ -1126,6 +1149,58 @@ class Test_Components extends WP_UnitTestCase {
 
 		$this->assertComponentEquals( $expected, $component );
 
+	}
+
+	/**
+	 * Test irving/term-provider component.
+	 *
+	 * @group core-components
+	 */
+	public function test_component_term_provider() {
+		// Register a component that receives the term_id context.
+		register_component(
+			'example/use-context',
+			[
+				'use_context' => [
+					'irving/term_id' => 'term_id',
+				],
+			]
+		);
+
+		$expected = $this->get_expected_component(
+			'irving/term-provider',
+			[
+				'_alias'   => 'irving/fragment',
+				'config'   => [
+					'termId' => $this->get_term_id(),
+				],
+				'children' => [
+					$this->get_expected_component(
+						'example/use-context',
+						[
+							'config' => [ 'termId' => $this->get_term_id() ],
+						]
+					),
+				],
+			]
+		);
+
+		$component = new Component(
+			'irving/term-provider',
+			[
+				'config'   => [
+					'term_id' => $this->get_term_id(),
+				],
+				'children' => [
+					[ 'name' => 'example/use-context' ],
+				],
+			]
+		);
+
+		// Cleanup.
+		unregister_component( 'example/use-context' );
+
+		$this->assertComponentEquals( $expected, $component );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
Implements the first three term components,
* Term provider - Similar to `irving/post-provider`; context provider for terms.
* Term name - Similar to `irving/post-title`; returns the term name as an `irving/text` component.
* Term link - Similar to `irving/post-permalinks`; returns the term link as an `irving/link` component.

Also,
* Adds `term_id` to the context store defaults.

## Ticket
[IRV-617](https://alleyinteractive.atlassian.net/browse/IRV-617)