### PR TITLE
Add interstitial support in the post list component

### DIFF
--- a/inc/components/class-component.php
+++ b/inc/components/class-component.php
@@ -555,6 +555,17 @@ class Component implements JsonSerializable {
 			$new_config = call_user_func_array( $this->config_callback, [ $new_config ] );
 		}
 
+		/**
+		 * Filter the config values after the config callback fires.
+		 *
+		 * Note: This fitler uses `after_hydration` instead of `post_hydration`
+		 * to avoid confusion with `post` in the WordPress context.
+		 *
+		 * @param array  $config Config for this component.
+		 * @param string $name   Name of this component.
+		 */
+		$new_config = apply_filters( 'wp_irving_component_config_after_hydration', $new_config, $this->get_name() );
+
 		// @todo Add error handling.
 		if ( is_array( $new_config ) ) {
 			$this->set_config( $new_config );

--- a/inc/components/class-component.php
+++ b/inc/components/class-component.php
@@ -558,7 +558,7 @@ class Component implements JsonSerializable {
 		/**
 		 * Filter the config values after the config callback fires.
 		 *
-		 * Note: This fitler uses `after_hydration` instead of `post_hydration`
+		 * Note: This filter uses `after_hydration` instead of `post_hydration`
 		 * to avoid confusion with `post` in the WordPress context.
 		 *
 		 * @param array  $config Config for this component.

--- a/inc/components/components/post-list/component.php
+++ b/inc/components/components/post-list/component.php
@@ -41,11 +41,12 @@ register_component_from_config(
 			$templates = wp_parse_args(
 				$config['templates'],
 				[
-					'before'     => [],
-					'after'      => [],
-					'wrapper'    => [],
-					'item'       => [],
-					'no_results' => [ __( 'No results found.', 'wp-irving' ) ],
+					'after'         => [],
+					'before'        => [],
+					'interstitials' => [],
+					'item'          => [],
+					'no_results'    => [ __( 'No results found.', 'wp-irving' ) ],
+					'wrapper'       => [],
 				]
 			);
 
@@ -76,6 +77,30 @@ register_component_from_config(
 				},
 				$post_ids
 			);
+
+			// Inject interstitals.
+			if ( ! empty( $templates['interstitials'] ) ) {
+				// Track each interstitial that successfully injects, to
+				// account for subsequent injections.
+				$additional_offset = 0;
+
+				foreach ( $templates['interstitials'] as $position => $interstitial ) {
+					if (
+						empty( $interstitial ) // $interstitial can't be empty.
+						|| ! is_array( $interstitial ) // Or an array.
+						|| absint( $position ) !== $position // $position must be an integer.
+						|| $position > count( $children ) // And we must have more children than the position.
+						|| array_keys( $interstitial ) !== range( 0, count( $interstitial ) - 1 ) // And ensure $interstitial is a sequential array.
+					) {
+						continue;
+					}
+
+					// Inject the interstitial.
+					array_splice( $children, $position + $additional_offset, 0, $interstitial );
+
+					$additional_offset++;
+				}
+			}
 
 			// If a list of components are set as a wrapper, only use the first.
 			$wrapper = $templates['wrapper'][0] ?? $templates['wrapper'];

--- a/tests/components/test-components.php
+++ b/tests/components/test-components.php
@@ -442,18 +442,18 @@ class Test_Components extends WP_UnitTestCase {
 
 		// Demo templates.
 		$templates = [
-			'before'  => [
+			'before'        => [
 				[ 'name' => 'example/before' ],
 			],
-			'after'   => [
+			'after'         => [
 				[ 'name' => 'example/after' ],
 			],
 			'wrapper'       => [ 'name' => 'example/wrapper' ],
 			'item'          => [ 'name' => 'example/item' ],
 			'interstitials' => [
 				0 => [
-					[ 'name' => 'example/interstitial' ]
-				]
+					[ 'name' => 'example/interstitial' ],
+				],
 			],
 		];
 

--- a/tests/components/test-components.php
+++ b/tests/components/test-components.php
@@ -448,8 +448,13 @@ class Test_Components extends WP_UnitTestCase {
 			'after'   => [
 				[ 'name' => 'example/after' ],
 			],
-			'wrapper' => [ 'name' => 'example/wrapper' ],
-			'item'    => [ 'name' => 'example/item' ],
+			'wrapper'       => [ 'name' => 'example/wrapper' ],
+			'item'          => [ 'name' => 'example/item' ],
+			'interstitials' => [
+				0 => [
+					[ 'name' => 'example/interstitial' ]
+				]
+			],
 		];
 
 		// Demo templates with item and wrapper in array format.
@@ -478,6 +483,7 @@ class Test_Components extends WP_UnitTestCase {
 						'example/wrapper',
 						[
 							'children' => [
+								$this->get_expected_component( 'example/interstitial' ),
 								$this->get_expected_component(
 									'irving/post-provider',
 									[


### PR DESCRIPTION
## Summary
* Adds a new `wp_irving_component_config_after_hydration` filter.
* Implements a new `interstitials` template key for the `irving/post-list` component.

Example,
```json
{
  "name": "irving/post-list",
  "config": {
    "templates": {
      "interstitials": {
        "3": [
          {
            "name": "your-interstitial-here/position-3"
          }
        ],
        "10": [
          {
            "name": "your-interstitial-here/position-10"
          }
        ]
      }
    }
  }
}
```

## Ticket
[IRV-617](https://alleyinteractive.atlassian.net/browse/IRV-617)