### PR TITLE
Fix how the yoast integration is formatted

### DIFF
--- a/inc/integrations/class-yoast.php
+++ b/inc/integrations/class-yoast.php
@@ -56,7 +56,7 @@ class Yoast {
 
 		// If the content exists, add it to the configuration array.
 		if ( ! empty( $content ) ) {
-			$config[] = [ 'yoast_schema' => [ 'content' => $content ] ];
+			$config['yoast_schema'] = [ 'content' => $content ];
 		}
 
 		return $config;


### PR DESCRIPTION
Fixes a bug where Yoast's schema isn't being set correctly on the integration manager's config.

Before PR:
![Screen Shot 2020-08-17 at 6 40 41 PM](https://user-images.githubusercontent.com/665107/90451236-5eaa1d80-e0b9-11ea-8dd2-7d3176ad4f4d.png)

After PR:
![Screen Shot 2020-08-17 at 6 41 27 PM](https://user-images.githubusercontent.com/665107/90451243-61a50e00-e0b9-11ea-9794-baf9d2c5a42e.png)
