### PR TITLE
Implement irving/term-list component

### DIFF
--- a/inc/components/components/term-list/component.json
+++ b/inc/components/components/term-list/component.json
@@ -1,0 +1,26 @@
+{
+  "name": "irving/term-list",
+  "_alias": "irving/fragment",
+  "category": "Term.",
+  "config": {
+    "templates": {
+      "default": [],
+      "hidden": true,
+      "type": "array"
+    },
+    "object_ids": {
+    },
+    "query_args": {
+      "default": [],
+      "hidden": true,
+      "type": "array"
+    },
+    "wp_term_query": {
+      "hidden": true,
+      "type": "object"
+    }
+  },
+  "provides_context": {
+    "irving/wp_term_query": "wp_term_query"
+  }
+}

--- a/inc/components/components/term-list/component.php
+++ b/inc/components/components/term-list/component.php
@@ -43,7 +43,7 @@ register_component_from_config(
 
 			$wp_term_query = $config['wp_term_query'];
 
-			// Bail early if no posts found.
+			// Bail early if no terms found.
 			if ( empty( $wp_term_query->terms ?? [] ) ) {
 				return $templates['no_results'];
 			}

--- a/inc/components/components/term-list/component.php
+++ b/inc/components/components/term-list/component.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Term list.
+ *
+ * List of terms.
+ *
+ * @package WP_Irving
+ */
+
+namespace WP_Irving\Components;
+
+use WP_Term;
+use WP_Term_Query;
+
+/**
+ * Register the component and callback.
+ */
+register_component_from_config(
+	__DIR__ . '/component',
+	[
+		'config_callback'   => function ( array $config ): array {
+
+			// Support provider context.
+			if ( isset( $config['object_ids'] ) ) {
+				$config['query_args']['object_ids'] = $config['object_ids'];
+			}
+
+			$config['wp_term_query'] = new WP_Term_Query( $config['query_args'] );
+			return $config;
+		},
+		'children_callback' => function ( array $children, array $config ): array {
+			$templates = wp_parse_args(
+				$config['templates'],
+				[
+					'after'         => [],
+					'before'        => [],
+					'interstitials' => [],
+					'item'          => [],
+					'no_results'    => [ __( 'No results found.', 'wp-irving' ) ],
+					'wrapper'       => [],
+				]
+			);
+
+			$wp_term_query = $config['wp_term_query'];
+
+			// Bail early if no posts found.
+			if ( empty( $wp_term_query->terms ?? [] ) ) {
+				return $templates['no_results'];
+			}
+
+
+			// Ensure single items are wrapped in an array.
+			$item = ( isset( $templates['item'][0] ) ) ? $templates['item'] : [ $templates['item'] ];
+
+			$children = array_map(
+				function ( $term_id ) use ( $item ) {
+					return [
+						'name'     => 'irving/term-provider',
+						'config'   => [
+							'term_id' => $term_id,
+						],
+						'children' => array_filter( $item ),
+					];
+				},
+				wp_list_pluck( $wp_term_query->terms, 'term_id' )
+			);
+
+			// Inject interstitals.
+			if ( ! empty( $templates['interstitials'] ) ) {
+				// Track each interstitial that successfully injects, to
+				// account for subsequent injections.
+				$additional_offset = 0;
+
+				foreach ( $templates['interstitials'] as $position => $interstitial ) {
+					if (
+						empty( $interstitial ) // $interstitial can't be empty.
+						|| ! is_array( $interstitial ) // Or an array.
+						|| absint( $position ) !== $position // $position must be an integer.
+						|| $position > count( $children ) // And we must have more children than the position.
+						|| array_keys( $interstitial ) !== range( 0, count( $interstitial ) - 1 ) // And ensure $interstitial is a sequential array.
+					) {
+						continue;
+					}
+
+					// Inject the interstitial.
+					array_splice( $children, $position + $additional_offset, 0, $interstitial );
+
+					$additional_offset++;
+				}
+			}
+
+			// If a list of components are set as a wrapper, only use the first.
+			$wrapper = $templates['wrapper'][0] ?? $templates['wrapper'];
+
+			// Wrap the children.
+			if ( ! empty( $wrapper ) ) {
+				$children = [
+					array_merge(
+						$wrapper,
+						[ 'children' => $children ]
+					),
+				];
+			}
+
+			// Prepend before components.
+			if ( ! empty( $templates['before'] ) ) {
+				array_unshift( $children, ...$templates['before'] );
+			}
+
+			// Append after components.
+			if ( ! empty( $templates['after'] ) ) {
+				array_push( $children, ...$templates['after'] );
+			}
+
+			return $children;
+		},
+	]
+);

--- a/inc/components/components/term-list/component.php
+++ b/inc/components/components/term-list/component.php
@@ -48,7 +48,6 @@ register_component_from_config(
 				return $templates['no_results'];
 			}
 
-
 			// Ensure single items are wrapped in an array.
 			$item = ( isset( $templates['item'][0] ) ) ? $templates['item'] : [ $templates['item'] ];
 

--- a/tests/components/test-components.php
+++ b/tests/components/test-components.php
@@ -1328,7 +1328,7 @@ class Test_Components extends WP_UnitTestCase {
 			'irving/term-list',
 			[
 				'_alias'   => 'irving/fragment',
-				'config'  => [
+				'config'   => [
 					'objectIds' => [ $this->get_post_id() ],
 				],
 				'children' => [

--- a/tests/components/test-components.php
+++ b/tests/components/test-components.php
@@ -1284,6 +1284,111 @@ class Test_Components extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test irving/term-list component.
+	 *
+	 * @group core-components
+	 */
+	public function test_component_term_list() {
+		// Demo templates.
+		$templates = [
+			'before'        => [
+				[ 'name' => 'example/before' ],
+			],
+			'after'         => [
+				[ 'name' => 'example/after' ],
+			],
+			'wrapper'       => [ 'name' => 'example/wrapper' ],
+			'item'          => [ 'name' => 'example/item' ],
+			'interstitials' => [
+				0 => [
+					[ 'name' => 'example/interstitial' ],
+				],
+			],
+		];
+
+		// Demo templates with item and wrapper in array format.
+		$templates_alt = [
+			'before'  => [
+				[ 'name' => 'example/before' ],
+			],
+			'after'   => [
+				[ 'name' => 'example/after' ],
+			],
+			'wrapper' => [
+				[ 'name' => 'example/wrapper' ],
+			],
+			'item'    => [
+				[ 'name' => 'example/item' ],
+			],
+		];
+
+		$categories = wp_get_post_categories( $this->get_post_id() );
+
+		$expected = $this->get_expected_component(
+			'irving/term-list',
+			[
+				'_alias'   => 'irving/fragment',
+				'config'  => [
+					'objectIds' => [ $this->get_post_id() ],
+				],
+				'children' => [
+					$this->get_expected_component( 'example/before' ),
+					$this->get_expected_component(
+						'example/wrapper',
+						[
+							'children' => [
+								$this->get_expected_component( 'example/interstitial' ),
+								$this->get_expected_component(
+									'irving/term-provider',
+									[
+										'_alias'   => 'irving/fragment',
+										'config'   => [
+											'termId' => $categories[0],
+										],
+										'children' => [
+											$this->get_expected_component( 'example/item' ),
+										],
+									]
+								),
+							],
+						]
+					),
+					$this->get_expected_component( 'example/after' ),
+				],
+			]
+		);
+
+		$component = new Component(
+			'irving/term-list',
+			[
+				'config' => [
+					'object_ids' => [ $this->get_post_id() ],
+					'query_args' => [
+						'taxonomy' => 'category',
+					],
+					'templates'  => $templates,
+				],
+			]
+		);
+
+		$component_alt = new Component(
+			'irving/term-list',
+			[
+				'config' => [
+					'object_ids' => [ $this->get_post_id() ],
+					'query_args' => [
+						'taxonomy' => 'category',
+					],
+					'templates'  => $templates,
+				],
+			]
+		);
+
+		$this->assertComponentEquals( $expected, $component );
+		$this->assertComponentEquals( $expected, $component_alt );
+	}
+
+	/**
 	 * Test irving/video component.
 	 *
 	 * @group core-components


### PR DESCRIPTION
## Summary
Implements a new `irving/term-list` component, which exposes a [`WP_Term_Query`](https://developer.wordpress.org/reference/classes/wp_term_query/) object.

## Screenshot
<img width="726" alt="Screen Shot 2020-08-18 at 3 33 56 PM" src="https://user-images.githubusercontent.com/665107/90557316-493ffc80-e168-11ea-9731-18c953972997.png">

## Example
Display all the tags for a given post in `single.json`
```json
{
  "name": "irving/term-list",
  "config": {
    "taxonomy": "post_tag",
    "templates": {
      "item": [
        {
          "name": "irving/term-link",
          "children": [
            {
              "name": "irving/term-name"
            }
          ]
        }
      ]
    }
  },
  "use_context": {
    "irving/post_id": "object_ids"
  }
}
```

## Note for reviewer
There is a lot of code duplicated from the `irving/post-list` component. While a refactor/abstraction would be useful, it's outside the scope of this work for now.