### PR TITLE
DEF-56: Setup Coral integration for JWT authentication

### DIFF
--- a/inc/integrations/class-coral.php
+++ b/inc/integrations/class-coral.php
@@ -39,9 +39,6 @@ class Coral {
 		// Register settings fields for integrations.
 		add_action( 'admin_init', [ $this, 'register_settings_fields' ] );
 
-		// Filter the updated option values prior to submission.
-		add_filter( 'pre_update_option_irving_integrations', [ $this, 'group_and_format_options_for_storage' ] );
-
 		$sso_secret = $this->options[ $this->option_key ]['sso_secret'] ?? false;
 
 		if ( ! empty( $sso_secret ) ){
@@ -81,29 +78,6 @@ class Coral {
 		?>
 			<input type="text" name="irving_integrations[<?php echo esc_attr( 'coral_sso_secret' ); ?>]" value="<?php echo esc_attr( $sso_secret ); ?>" />
 		<?php
-	}
-
-	/**
-	 * Loop through the updated options, group them by their integration's key,
-	 * and remove any prefix set by the option's input.
-	 *
-	 * @param array $options The updated options.
-	 * @return array The formatted options.
-	 */
-	public function group_and_format_options_for_storage( array $options ): array {
-		$formatted_options = [];
-
-		foreach ( $options as $key => $val ) {
-			// Build the config array for Coral.
-			if ( strpos( $key, 'coral_' ) !== false) {
-				$formatted_options[ $this->option_key ][ str_replace( 'coral_', '', $key ) ] = $val;
-			}
-		}
-
-		// Make sure this option's values are not passed to the endpoint.
-		$formatted_options[ $this->option_key ]['private'] = true;
-
-		return $formatted_options;
 	}
 
 	/**
@@ -160,8 +134,6 @@ class Coral {
 	 * @return string The constructed JWT.
 	 */
 	public function build_jwt( array $credentials ): string {
-		$options = get_option( 'irving_integrations' );
-
 		// Define the JWT header and payload.
 		$header     = json_encode( [ 'typ' => 'JWT', 'alg' => 'HS256' ] );
 		$payload    = json_encode( $credentials );

--- a/inc/integrations/class-coral.php
+++ b/inc/integrations/class-coral.php
@@ -41,7 +41,7 @@ class Coral {
 
 		$sso_secret = $this->options[ $this->option_key ]['sso_secret'] ?? false;
 
-		if ( ! empty( $sso_secret ) ){
+		if ( ! empty( $sso_secret ) ) {
 			// Expose data to the endpoint.
 			add_filter(
 				'wp_irving_data_endpoints',
@@ -113,13 +113,13 @@ class Coral {
 		$verified_user = apply_filters( 'wp_irving_verify_coral_user', $user_obj );
 
 		// Bail early if the verified user doesn't exist.
-		if ( empty ( $verified_user ) ) {
+		if ( empty( $verified_user ) ) {
 			return [ 'status' => 'failed' ];
 		}
 
 		$credentials = [
 			'jti'  => uniqid(),
-			'exp'  => time() + (90 * DAY_IN_SECONDS), // JWT will expire in 90 days.
+			'exp'  => time() + ( 90 * DAY_IN_SECONDS ), // JWT will expire in 90 days.
 			'iat'  => time(),
 			'user' => [
 				'id'       => $verified_user['id'],
@@ -142,9 +142,14 @@ class Coral {
 	 */
 	public function build_jwt( array $credentials ): string {
 		// Define the JWT header and payload.
-		$header     = json_encode( [ 'typ' => 'JWT', 'alg' => 'HS256' ] );
-		$payload    = json_encode( $credentials );
-		$secret     = $this->options[ $this->option_key ]['sso_secret'];
+		$header  = wp_json_encode(
+			[
+				'typ' => 'JWT',
+				'alg' => 'HS256'
+			]
+		);
+		$payload = wp_json_encode( $credentials );
+		$secret  = $this->options[ $this->option_key ]['sso_secret'];
 
 		// Base64 URL encode the header and payload.
 		$base64_header  = $this->base64url_encode( $header );
@@ -156,7 +161,7 @@ class Coral {
 		$base64_signature = $this->base64url_encode( $signature );
 
 		// Return the built JWT.
-		return $base64_header . "." . $base64_payload . '.' . $base64_signature;
+		return $base64_header . '.' . $base64_payload . '.' . $base64_signature;
 	}
 
 	/**

--- a/inc/integrations/class-coral.php
+++ b/inc/integrations/class-coral.php
@@ -61,11 +61,19 @@ class Coral {
 	 * Register settings fields for display.
 	 */
 	public function register_settings_fields() {
-		// Register a new field for the Coral integration.
+		// Register new fields for the Coral integration.
 		add_settings_field(
-			'wp_irving_ga_tracking_id',
+			'wp_irving_coral_sso_secret',
 			esc_html__( 'Coral SSO Secret', 'wp-irving' ),
 			[ $this, 'render_coral_sso_secret_input' ],
+			'wp_irving_integrations',
+			'irving_integrations_settings'
+        );
+
+		add_settings_field(
+			'wp_irving_coral_pico_sso_enabled',
+			esc_html__( 'Enable Coral SSO with Pico', 'wp-irving' ),
+			[ $this, 'render_pico_sso_enabled_checkbox' ],
 			'wp_irving_integrations',
 			'irving_integrations_settings'
 		);
@@ -79,7 +87,19 @@ class Coral {
 		$sso_secret = $this->options[ $this->option_key ]['sso_secret'] ?? '';
 
 		?>
-			<input type="text" name="irving_integrations[<?php echo esc_attr( 'sso_secret' ); ?>]" value="<?php echo esc_attr( $sso_secret ); ?>" />
+			<input type="text" name="irving_integrations[<?php echo esc_attr( 'coral_sso_secret' ); ?>]" value="<?php echo esc_attr( $sso_secret ); ?>" />
+		<?php
+    }
+
+    /**
+	 * Render an checkbox that will register the Pico verification endpoint.
+	 */
+	public function render_pico_sso_enabled_checkbox() {
+		// Check to see if Pico SSO is enabled in the option.
+		$sso_enabled = $this->options[ $this->option_key ]['pico_sso_enabled'] ?? false;
+
+		?>
+			<input type="checkbox" name="irving_integrations[<?php echo esc_attr( 'coral_pico_sso_enabled' ); ?>]" value="<?php echo esc_attr( $sso_enabled ); ?>" />
 		<?php
 	}
 
@@ -95,10 +115,13 @@ class Coral {
 
 		foreach ( $options as $key => $val ) {
 			// Build the config array for Coral.
-			if ( strpos( $key, 'ga_' ) !== false ) {
-				$formatted_options[ $this->option_key ][ str_replace( 'ga_', '', $key ) ] = $val;
+			if ( strpos( $key, 'coral_' ) !== false) {
+				$formatted_options[ $this->option_key ][ str_replace( 'coral_', '', $key ) ] = $val;
 			}
-		}
+        }
+
+        // Make sure this option's values are not passed to the endpoint.
+        $formatted_options[ $this->option_key ]['private'] = true;
 
 		return $formatted_options;
     }

--- a/inc/integrations/class-coral.php
+++ b/inc/integrations/class-coral.php
@@ -145,7 +145,7 @@ class Coral {
 		$header  = wp_json_encode(
 			[
 				'typ' => 'JWT',
-				'alg' => 'HS256'
+				'alg' => 'HS256',
 			]
 		);
 		$payload = wp_json_encode( $credentials );

--- a/inc/integrations/class-coral.php
+++ b/inc/integrations/class-coral.php
@@ -98,7 +98,10 @@ class Coral {
 	 * @param \WP_REST_Request $request The request object.
 	 */
 	public function process_endpoint_request( \WP_REST_Request $request ) {
-		$user = sanatize_text_field( $request->get_param( 'user' ) );
+		// Allow access from the frontend.
+		header( 'Access-Control-Allow-Origin: ' . home_url() );
+
+		$user = sanitize_text_field( $request->get_param( 'user' ) );
 
 		$user_obj = [
 			'id'       => '628bdc61-6616-4add-bfec-dd79156715d4', // The ID should come from the Pico verification payload.

--- a/inc/integrations/class-coral.php
+++ b/inc/integrations/class-coral.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * WP Irving integration for Coral.
+ *
+ * @package WP_Irving;
+ */
+
+namespace WP_Irving\Integrations;
+
+use WP_Irving\Singleton;
+
+/**
+ * Class to integrate Coral with Irving.
+ */
+class Coral {
+	use Singleton;
+
+	/**
+	 * The option key for the integration.
+	 *
+	 * @var string
+	 */
+	private $option_key = 'coral';
+
+	/**
+	 * Holds the option values to be set.
+	 *
+	 * @var array
+	 */
+	private $options;
+
+	/**
+	 * Setup the singleton. Validate JWT is installed, and setup hooks.
+	 */
+	public function setup() {
+		// Retrieve any existing integrations options.
+        $this->options = get_option( 'irving_integrations' );
+
+		// Register settings fields for integrations.
+		add_action( 'admin_init', [ $this, 'register_settings_fields' ] );
+
+		// Filter the updated option values prior to submission.
+        add_filter( 'pre_update_option_irving_integrations', [ $this, 'group_and_format_options_for_storage' ] );
+
+        $pico_sso_enabled = $this->options[ $this->option_key ]['pico_sso_enabled'] ?? false;
+    
+        if ( ! empty( $pico_sso_enabled ) ){
+            // Expose data to the endpoint.
+            add_filter(
+                'wp_irving_data_endpoints',
+                function ( $endpoints ) {
+                    $endpoints[] = $this->get_endpoint_settings();
+
+                    return $endpoints;
+                }
+            );
+        }
+	}
+
+	/**
+	 * Register settings fields for display.
+	 */
+	public function register_settings_fields() {
+		// Register a new field for the Coral integration.
+		add_settings_field(
+			'wp_irving_ga_tracking_id',
+			esc_html__( 'Coral SSO Secret', 'wp-irving' ),
+			[ $this, 'render_coral_sso_secret_input' ],
+			'wp_irving_integrations',
+			'irving_integrations_settings'
+		);
+	}
+
+	/**
+	 * Render an input for the Coral SSO secret.
+	 */
+	public function render_coral_sso_secret_input() {
+		// Check to see if there is an existing SSO secret in the option.
+		$sso_secret = $this->options[ $this->option_key ]['sso_secret'] ?? '';
+
+		?>
+			<input type="text" name="irving_integrations[<?php echo esc_attr( 'sso_secret' ); ?>]" value="<?php echo esc_attr( $sso_secret ); ?>" />
+		<?php
+	}
+
+	/**
+	 * Loop through the updated options, group them by their integration's key,
+	 * and remove any prefix set by the option's input.
+	 *
+	 * @param array $options The updated options.
+	 * @return array The formatted options.
+	 */
+	public function group_and_format_options_for_storage( array $options ): array {
+		$formatted_options = [];
+
+		foreach ( $options as $key => $val ) {
+			// Build the config array for Coral.
+			if ( strpos( $key, 'ga_' ) !== false ) {
+				$formatted_options[ $this->option_key ][ str_replace( 'ga_', '', $key ) ] = $val;
+			}
+		}
+
+		return $formatted_options;
+    }
+    
+
+    /**
+     * Get the endpoint settings.
+     *
+     * @return array Endpoint settings.
+     */
+	public function get_endpoint_settings(): array {
+		return [
+			'slug'     => 'verify_pico_user',
+			'callback' => [ $this, 'process_endpoint_request' ],
+		];
+	}
+
+    /**
+     * Get the data for the Pico user endpoint verification request.
+     *
+     * @param \WP_REST_Request $request The request object.
+     */
+	public function process_endpoint_request( \WP_REST_Request $request ) {
+		// Allow access from the frontend.
+		header( 'Access-Control-Allow-Origin: ' . home_url() );
+
+		$user = $request->get_param( 'user' );
+
+		if ( ! empty( $user ) ) {
+			$credentials = [
+				'jti'  => uniqid(),
+				'exp'  => time() + (90 * 86400), // JWT will expire in 90 days.
+				'iat'  => time(),
+				'user' => [
+					'id'       => '628bdc61-6616-4add-bfec-dd79156715d4', // This will be retrieved from the Pico verification response. Fix this later.
+					'email'    => $user,
+					'username' => explode( '@', $user ),
+				],
+			];
+
+			// Build the JWT.
+			$jwt = $base64_header . "." . $base64_payload . '.' . $base64_signature;
+
+			return [
+				'status' => 'success',
+				'jwt'    => $jwt,
+			];
+		}
+
+		return [ 'status' => 'failed' ];
+	}
+
+    /**
+     * Construct a HS256-encrypted JWT for SSO authentication.
+     *
+     * @param array $credentials The user to be authenticated.
+     * @return string The constructed JWT.
+     */
+	public function build_jwt( array $credentials ): string {
+		// Define the JWT header and payload.
+		$header     = json_encode( [ 'typ' => 'JWT', 'alg' => 'HS256' ] );
+		$payload    = json_encode( $credentials );
+		$secret     = $this->options[ $this->option_key ]['sso_secret'];
+
+		// Base64 URL encode the header and payload.
+		$base64_header  = $this->base64url_encode( $header );
+		$base64_payload = $this->base64url_encode( $payload );
+
+		// Generate the JWT signature.
+		$signature = hash_hmac( 'sha256', $base64_header . '.' . $base64_payload, $secret, true );
+		// Base64 URL encode the signature.
+		$base64_signature = $this->base64url_encode( $signature );
+
+		// Return the built JWT.
+		return $base64_header . "." . $base64_payload . '.' . $base64_signature;
+	}
+
+    /**
+     * Base64 URL encode a target data string.
+     *
+     * @param string $data The data to be encoded.
+     * @return string The encoded data.
+     */
+	public function base64url_encode( string $data ): string {
+		return rtrim( strtr( base64_encode( $data ), '+/', '-_' ), '=' );
+	}
+}

--- a/inc/integrations/class-google-analytics.php
+++ b/inc/integrations/class-google-analytics.php
@@ -38,9 +38,6 @@ class Google_Analytics {
 
 		// Register settings fields for integrations.
 		add_action( 'admin_init', [ $this, 'register_settings_fields' ] );
-
-		// Filter the updated option values prior to submission.
-		add_filter( 'pre_update_option_irving_integrations', [ $this, 'group_and_format_options_for_storage' ] );
 	}
 
 	/**
@@ -67,25 +64,5 @@ class Google_Analytics {
 		?>
 			<input type="text" name="irving_integrations[<?php echo esc_attr( 'ga_tracking_id' ); ?>]" value="<?php echo esc_attr( $ga_key ); ?>" />
 		<?php
-	}
-
-	/**
-	 * Loop through the updated options, group them by their integration's key,
-	 * and remove any prefix set by the option's input.
-	 *
-	 * @param array $options The updated options.
-	 * @return array The formatted options.
-	 */
-	public function group_and_format_options_for_storage( array $options ): array {
-		$formatted_options = [];
-
-		foreach ( $options as $key => $val ) {
-			// Build the config array for Google Analytics.
-			if ( strpos( $key, 'ga_' ) !== false ) {
-				$formatted_options[ $this->option_key ][ str_replace( 'ga_', '', $key ) ] = $val;
-			}
-		}
-
-		return $formatted_options;
 	}
 }

--- a/inc/integrations/class-integrations-manager.php
+++ b/inc/integrations/class-integrations-manager.php
@@ -59,13 +59,17 @@ class Integrations_Manager {
 
 		foreach ( $options as $key => $val ) {
 			switch ( $key ) {
-				case strpos( $key, 'ga_' ) !== false: // Build the config array for GA.
+				// Build the config array for GA.
+				case strpos( $key, 'ga_' ) !== false:
 					$formatted_options['google_analytics'][ str_replace( 'ga_', '', $key ) ] = $val;
-				case strpos( $key, 'coral_' ) !== false: // Build the config array for Coral.
+					break;
+				// Build the config array for Coral.
+				case strpos( $key, 'coral_' ) !== false:
 					$formatted_options['coral'][ str_replace( 'coral_', '', $key ) ] = $val;
 					// Set the options to private. This will prevent them from being passed through
 					// the components JSON endpoint.
 					$formatted_options['coral']['private'] = true;
+					break;
 				default:
 					$formatted_options[ $key ] = $val;
 			}

--- a/inc/integrations/class-integrations-manager.php
+++ b/inc/integrations/class-integrations-manager.php
@@ -66,7 +66,7 @@ class Integrations_Manager {
 				// Build the contig array for GTM.
 				case strpos( $key, 'gtm_' ) !== false:
 					$formatted_options['google_tag_manager'][ str_replace( 'gtm_', '', $key ) ] = $val;
-		 			break;
+					break;
 				// Build the config array for Coral.
 				case strpos( $key, 'coral_' ) !== false:
 					$formatted_options['coral'][ str_replace( 'coral_', '', $key ) ] = $val;

--- a/inc/integrations/class-integrations-manager.php
+++ b/inc/integrations/class-integrations-manager.php
@@ -24,8 +24,12 @@ class Integrations_Manager {
 	public function setup() {
 		// Register admin page.
 		add_action( 'admin_menu', [ $this, 'register_admin' ] );
+
 		// Register settings fields for integrations.
 		add_action( 'admin_init', [ $this, 'register_settings_fields' ] );
+
+		// Filter the updated option values prior to submission.
+		add_filter( 'pre_update_option_irving_integrations', [ $this, 'group_and_format_options_for_storage' ] );
 	}
 
 	/**
@@ -37,10 +41,35 @@ class Integrations_Manager {
 		// Register the section.
 		add_settings_section(
 			'irving_integrations_settings',
-			__( 'Add keys for integrations to be passed to the front-end.', 'wp-irving' ),
+			__( 'Add keys for integrations.', 'wp-irving' ),
 			'',
 			'wp_irving_integrations'
 		);
+	}
+
+	/**
+	 * Loop through the updated options, group them by their integration's key,
+	 * and remove any prefix set by the option's input.
+	 *
+	 * @param array $options The updated options.
+	 * @return array The formatted options.
+	 */
+	public function group_and_format_options_for_storage( array $options ): array {
+		$formatted_options = [];
+
+		foreach ( $options as $key => $val ) {
+			// Build the config array for GA.
+			if ( strpos( $key, 'ga_' ) !== false ) {
+				$formatted_options['google_analytics'][ str_replace( 'ga_', '', $key ) ] = $val;
+			}
+			// Build the config array for Coral.
+			if ( strpos( $key, 'coral_' ) !== false) {
+				$formatted_options['coral'][ str_replace( 'coral_', '', $key ) ] = $val;
+				$formatted_options['coral']['private'] = true;
+			}
+		}
+
+		return $formatted_options;
 	}
 
 	/**

--- a/inc/integrations/class-integrations-manager.php
+++ b/inc/integrations/class-integrations-manager.php
@@ -58,14 +58,16 @@ class Integrations_Manager {
 		$formatted_options = [];
 
 		foreach ( $options as $key => $val ) {
-			// Build the config array for GA.
-			if ( strpos( $key, 'ga_' ) !== false ) {
-				$formatted_options['google_analytics'][ str_replace( 'ga_', '', $key ) ] = $val;
-			}
-			// Build the config array for Coral.
-			if ( strpos( $key, 'coral_' ) !== false) {
-				$formatted_options['coral'][ str_replace( 'coral_', '', $key ) ] = $val;
-				$formatted_options['coral']['private'] = true;
+			switch ( $key ) {
+				case strpos( $key, 'ga_' ) !== false:
+					// Build the config array for GA.
+					$formatted_options['google_analytics'][ str_replace( 'ga_', '', $key ) ] = $val;
+				case strpos( $key, 'coral_' ) !== false:
+					// Build the config array for Coral.
+					$formatted_options['coral'][ str_replace( 'coral_', '', $key ) ] = $val;
+					$formatted_options['coral']['private'] = true;
+				default:
+					$formatted_options[ $key ] = $val;
 			}
 		}
 

--- a/inc/integrations/class-integrations-manager.php
+++ b/inc/integrations/class-integrations-manager.php
@@ -59,12 +59,12 @@ class Integrations_Manager {
 
 		foreach ( $options as $key => $val ) {
 			switch ( $key ) {
-				case strpos( $key, 'ga_' ) !== false:
-					// Build the config array for GA.
+				case strpos( $key, 'ga_' ) !== false: // Build the config array for GA.
 					$formatted_options['google_analytics'][ str_replace( 'ga_', '', $key ) ] = $val;
-				case strpos( $key, 'coral_' ) !== false:
-					// Build the config array for Coral.
+				case strpos( $key, 'coral_' ) !== false: // Build the config array for Coral.
 					$formatted_options['coral'][ str_replace( 'coral_', '', $key ) ] = $val;
+					// Set the options to private. This will prevent them from being passed through
+					// the components JSON endpoint.
 					$formatted_options['coral']['private'] = true;
 				default:
 					$formatted_options[ $key ] = $val;

--- a/inc/integrations/class-integrations-manager.php
+++ b/inc/integrations/class-integrations-manager.php
@@ -63,10 +63,10 @@ class Integrations_Manager {
 				case strpos( $key, 'ga_' ) !== false:
 					$formatted_options['google_analytics'][ str_replace( 'ga_', '', $key ) ] = $val;
 					break;
-        // Build the contig array for GTM.
+				// Build the contig array for GTM.
 				case strpos( $key, 'gtm_' ) !== false:
 					$formatted_options['google_tag_manager'][ str_replace( 'gtm_', '', $key ) ] = $val;
-          break;
+		 			break;
 				// Build the config array for Coral.
 				case strpos( $key, 'coral_' ) !== false:
 					$formatted_options['coral'][ str_replace( 'coral_', '', $key ) ] = $val;

--- a/inc/integrations/class-pico.php
+++ b/inc/integrations/class-pico.php
@@ -62,7 +62,7 @@ class Pico {
 		return $options;
 	}
 
-	public function verify_pico_user_for_sso( string $user ): array {
+	public function verify_pico_user_for_sso( array $user ): array {
 		// TODO: Dispatch a verification request to the Pico API. If the user
 		// is verified, return the constructed user with an ID, email, and
 		// username.

--- a/inc/integrations/class-pico.php
+++ b/inc/integrations/class-pico.php
@@ -62,6 +62,13 @@ class Pico {
 		return $options;
 	}
 
+	/**
+	 * Validate a Pico user's credentials and return the required credentials
+	 * to build a JWT.
+	 *
+	 * @param array $user The initial user object.
+	 * @return array Updated user object.
+	 */
 	public function verify_pico_user_for_sso( array $user ): array {
 		// TODO: Dispatch a verification request to the Pico API. If the user
 		// is verified, return the constructed user with an ID, email, and

--- a/inc/integrations/class-pico.php
+++ b/inc/integrations/class-pico.php
@@ -34,6 +34,8 @@ class Pico {
 			// Wrap content with `<div id="pico"></div>`.
 			add_filter( 'the_content', [ 'Pico_Widget', 'filter_content' ] );
 		}
+
+		add_filter( 'wp_irving_verify_coral_user', [ $this, 'verify_pico_user_for_sso' ] );
 	}
 
 	/**
@@ -58,5 +60,19 @@ class Pico {
 		$options['pico']['page_info']['taxonomies'] = (object) ( $options['pico']['page_info']['taxonomies'] ?? [] );
 
 		return $options;
+	}
+
+	public function verify_pico_user_for_sso( string $user ): array {
+		// TODO: Dispatch a verification request to the Pico API. If the user
+		// is verified, return the constructed user with an ID, email, and
+		// username.
+		// If the user isn't verified, return false, which will cause a failure
+		// response to be returned on the front-end and the appropriate behavior
+		// will be triggered.
+		return [
+			'id'       => '628bdc61-6616-4add-bfec-dd79156715d4', // The ID should come from the Pico verification payload.
+			'email'    => $user,
+			'username' => explode( '@', $user )[0], // The username should come from the Pico verification payload.
+		];
 	}
 }

--- a/inc/integrations/class-pico.php
+++ b/inc/integrations/class-pico.php
@@ -69,10 +69,6 @@ class Pico {
 		// If the user isn't verified, return false, which will cause a failure
 		// response to be returned on the front-end and the appropriate behavior
 		// will be triggered.
-		return [
-			'id'       => '628bdc61-6616-4add-bfec-dd79156715d4', // The ID should come from the Pico verification payload.
-			'email'    => $user,
-			'username' => explode( '@', $user )[0], // The username should come from the Pico verification payload.
-		];
+		return $user;
 	}
 }

--- a/inc/integrations/namespace.php
+++ b/inc/integrations/namespace.php
@@ -21,6 +21,7 @@ function bootstrap() {
 function load_integrations_manager() {
 	// Instantiate the integrations manager.
 	$manager = new \WP_Irving\Integrations\Integrations_Manager();
+	$manager->setup();
 
 	// Register integrations.
 	auto_register_integrations();
@@ -32,6 +33,7 @@ function load_integrations_manager() {
 function auto_register_integrations() {
 	$integrations = [
 		'archiveless'             => __NAMESPACE__ . '\Archiveless',
+		'coral'                   => __NAMESPACE__ . '\Coral',
 		'google_analytics'        => __NAMESPACE__ . '\Google_Analytics',
 		'google_amp'              => __NAMESPACE__ . '\Google_AMP',
 		'new_relic'               => __NAMESPACE__ . '\New_Relic',

--- a/inc/templates/namespace.php
+++ b/inc/templates/namespace.php
@@ -571,7 +571,7 @@ function setup_integrations( array $data, WP_Query $query, string $context ): ar
 		$options,
 		function( $option ) {
 			// Don't pass private options in the endpoint response.
-			if ( ! empty ( $option['private'] ) ) {
+			if ( ! empty( $option['private'] ) ) {
 				return;
 			}
 

--- a/inc/templates/namespace.php
+++ b/inc/templates/namespace.php
@@ -570,6 +570,11 @@ function setup_integrations( array $data, WP_Query $query, string $context ): ar
 	$options = array_filter(
 		$options,
 		function( $option ) {
+			// Don't pass private options in the endpoint response.
+			if ( ! empty ( $option['private'] ) ) {
+				return;
+			}
+
 			foreach ( $option as $key => $value ) {
 				return ! empty( $value ) ?? [ $key => $value ];
 			}

--- a/wp-irving.php
+++ b/wp-irving.php
@@ -36,6 +36,7 @@ require_once WP_IRVING_PATH . '/inc/endpoints/class-cache-endpoint.php';
 
 // Integrations.
 require_once WP_IRVING_PATH . '/inc/integrations/class-archiveless.php';
+require_once WP_IRVING_PATH . '/inc/integrations/class-coral.php';
 require_once WP_IRVING_PATH . '/inc/integrations/class-google-amp.php';
 require_once WP_IRVING_PATH . '/inc/integrations/class-google-analytics.php';
 require_once WP_IRVING_PATH . '/inc/integrations/class-jwt-auth.php';


### PR DESCRIPTION
__The core front-end work for enabling Coral JWT auth can be found at alleyinteractive/irving#275__

## Summary
The work for this PR introduces a new WP integration for the `Coral` component that adds a settings field to the Irving Integrations options page in the WP admin that allows users to enter a Coral SSO token for use with a given SSO provider. At the outset, the only provider that can hook into this integration is Pico, however there exists a generic filter `wp_irving_verify_coral_user`, that can be hooked into by other SSO providers in the future should such a need arise.

If a user adds an SSO token, a new JSON endpoint is registered, `validate_sso_user` that allows the front-end to make a request to WordPress with base user credentials, run them through a validation hook, and return a signed JWT that can be saved in a cookie and used to sign in or create a user account in Coral.