### PR TITLE
Components: Add coral-comment-counts component

### DIFF
--- a/inc/components/components/coral-comment-count/component.json
+++ b/inc/components/components/coral-comment-count/component.json
@@ -1,0 +1,26 @@
+{
+    "name": "irving/coral-comment-count",
+    "description": "",
+    "config": {
+        "article_URL": {
+          "default": "",
+          "type": "string"
+        },
+        "embed_URL": {
+          "default": "",
+          "type": "string"
+        },
+        "no_text": {
+          "default": false,
+          "type": "bool"
+        },
+        "post_id": {
+          "default": 0,
+          "type": "int",
+          "hidden": true
+        }
+    },
+    "use_context": {
+      "irving/post_id": "post_id"
+    }
+}

--- a/inc/components/components/coral-comment-count/component.php
+++ b/inc/components/components/coral-comment-count/component.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Coral embed.
+ *
+ * Insert a coral instance on a given template.
+ *
+ * @package WP_Irving
+ */
+
+namespace WP_Irving\Components;
+
+/**
+ * Register the component.
+ */
+register_component_from_config(
+	__DIR__ . '/component',
+	[
+		'config_callback' => function ( $config ) {
+			// Bail early if there's no post ID.
+			if ( ! $config['post_id'] ) {
+				return $config;
+			}
+
+			return array_merge(
+				$config,
+				[
+					'article_URL' => get_the_permalink( $config['post_id'] ),
+				]
+			);
+		},
+	]
+);

--- a/inc/components/components/coral-comment-count/component.php
+++ b/inc/components/components/coral-comment-count/component.php
@@ -9,6 +9,8 @@
 
 namespace WP_Irving\Components;
 
+use WP_Irving\Integrations;
+
 /**
  * Register the component.
  */
@@ -24,6 +26,7 @@ register_component_from_config(
 			return array_merge(
 				$config,
 				[
+					'embed_URL'   => Integrations\get_option( 'coral', 'url' ),
 					'article_URL' => get_the_permalink( $config['post_id'] ),
 				]
 			);

--- a/inc/integrations/class-coral.php
+++ b/inc/integrations/class-coral.php
@@ -60,12 +60,32 @@ class Coral {
 	public function register_settings_fields() {
 		// Register new fields for the Coral integration.
 		add_settings_field(
+			'wp_irving_coral_url',
+			esc_html__( 'Coral URL', 'wp-irving' ),
+			[ $this, 'render_coral_url_input' ],
+			'wp_irving_integrations',
+			'irving_integrations_settings'
+		);
+
+		add_settings_field(
 			'wp_irving_coral_sso_secret',
 			esc_html__( 'Coral SSO Secret', 'wp-irving' ),
 			[ $this, 'render_coral_sso_secret_input' ],
 			'wp_irving_integrations',
 			'irving_integrations_settings'
 		);
+	}
+
+	/**
+	 * Render an input for the Coral URL.
+	 */
+	public function render_coral_url_input() {
+		// Check to see if there is an existing SSO secret in the option.
+		$coral_url = $this->options[ $this->option_key ]['url'] ?? '';
+
+		?>
+			<input type="text" name="irving_integrations[<?php echo esc_attr( 'coral_url' ); ?>]" value="<?php echo esc_attr( $coral_url ); ?>" />
+		<?php
 	}
 
 	/**

--- a/inc/integrations/namespace.php
+++ b/inc/integrations/namespace.php
@@ -83,3 +83,24 @@ function load_integrations( array $integrations ) {
 		}
 	}
 }
+
+/**
+ * Get option values for an integration.
+ *
+ * @param string $integration The integration slug.
+ * @param string $option      Optional. The option key to return. If empty,
+ *                            all options for that integration will be returned
+ *                            as an array.
+ * @return mixed Option value or an array of values.
+ */
+function get_option( string $integration, string $option = '' ) {
+	$options = \get_option( 'irving_integrations' );
+
+	// When no option is passed, return all options for the integration.
+	if ( empty( $option ) ) {
+		return $options[$integration] ?? [];
+	}
+
+	// Return the specific option.
+	return $options[$integration][$option] ?? false;
+}

--- a/inc/integrations/namespace.php
+++ b/inc/integrations/namespace.php
@@ -98,9 +98,9 @@ function get_option( string $integration, string $option = '' ) {
 
 	// When no option is passed, return all options for the integration.
 	if ( empty( $option ) ) {
-		return $options[$integration] ?? [];
+		return $options[ $integration ] ?? [];
 	}
 
 	// Return the specific option.
-	return $options[$integration][$option] ?? false;
+	return $options[ $integration ][ $option ] ?? false;
 }

--- a/tests/components/test-components.php
+++ b/tests/components/test-components.php
@@ -1439,7 +1439,7 @@ class Test_Components extends WP_UnitTestCase {
 			[
 				'config' => [
 					'articleUrl' => get_the_permalink( self::$post_id ),
-					'embedUrl' => 'https://example.coral.test',
+					'embedUrl'   => 'https://example.coral.test',
 					'noText'     => false,
 				],
 			]

--- a/tests/components/test-components.php
+++ b/tests/components/test-components.php
@@ -1450,7 +1450,7 @@ class Test_Components extends WP_UnitTestCase {
 				'config' => [
 					'embed_URL' => 'https://example.coral.test',
 					'post_id'   => self::$post_id,
-				]
+				],
 			]
 		);
 

--- a/tests/components/test-components.php
+++ b/tests/components/test-components.php
@@ -1433,11 +1433,11 @@ class Test_Components extends WP_UnitTestCase {
 	 * @group coral
 	 */
 	public function test_component_coral_comment_counts() {
+
 		$expected = $this->get_expected_component(
 			'irving/coral-comment-count',
 			[
 				'config' => [
-					'embedUrl'   => 'https://example.coral.test',
 					'articleUrl' => get_the_permalink( self::$post_id ),
 					'noText'     => false,
 				],

--- a/tests/components/test-components.php
+++ b/tests/components/test-components.php
@@ -1458,7 +1458,6 @@ class Test_Components extends WP_UnitTestCase {
 		$this->assertComponentEquals( $expected, $component );
 	}
 
-
 	/**
 	 * Helper for creating expected output for components.
 	 *

--- a/tests/components/test-components.php
+++ b/tests/components/test-components.php
@@ -1439,6 +1439,7 @@ class Test_Components extends WP_UnitTestCase {
 			[
 				'config' => [
 					'articleUrl' => get_the_permalink( self::$post_id ),
+					'embedUrl' => 'https://example.coral.test',
 					'noText'     => false,
 				],
 			]

--- a/tests/components/test-components.php
+++ b/tests/components/test-components.php
@@ -1427,6 +1427,38 @@ class Test_Components extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test irving/coral-comment-counts component.
+	 *
+	 * @group core-components
+	 * @group coral
+	 */
+	public function test_component_coral_comment_counts() {
+		$expected = $this->get_expected_component(
+			'irving/coral-comment-count',
+			[
+				'config' => [
+					'embedUrl'   => 'https://example.coral.test',
+					'articleUrl' => get_the_permalink( self::$post_id ),
+					'noText'     => false,
+				],
+			]
+		);
+
+		$component = new Component(
+			'irving/coral-comment-count',
+			[
+				'config' => [
+					'embed_URL' => 'https://example.coral.test',
+					'post_id'   => self::$post_id,
+				]
+			]
+		);
+
+		$this->assertComponentEquals( $expected, $component );
+	}
+
+
+	/**
 	 * Helper for creating expected output for components.
 	 *
 	 * Returns default values so you don't have to write as much boilerplate.


### PR DESCRIPTION
This adds a new component named `irving/coral-comment-counts` that can be used
for displaying the number of comments on a specific post.

Other updates:

* Adds field on the integrations settings page for setting the Coral URL value.
* Adds a new helper function `WP-Irving\Integrations\get_option()` for getting a specific integration option value. See e9e7b94.