### PR TITLE
Fix bugs getting comment count values.

### DIFF
--- a/inc/components/components/coral-comment-count/component.php
+++ b/inc/components/components/coral-comment-count/component.php
@@ -26,7 +26,7 @@ register_component_from_config(
 			return array_merge(
 				$config,
 				[
-					'embed_URL'   => Integrations\get_option( 'coral', 'url' ),
+					'embed_URL'   => untrailingslashit( Integrations\get_option_value( 'coral', 'url' ) ),
 					'article_URL' => get_the_permalink( $config['post_id'] ),
 				]
 			);

--- a/inc/integrations/namespace.php
+++ b/inc/integrations/namespace.php
@@ -93,7 +93,7 @@ function load_integrations( array $integrations ) {
  *                            as an array.
  * @return mixed Option value or an array of values.
  */
-function get_option( string $integration, string $option = '' ) {
+function get_option_value( string $integration, string $option = '' ) {
 	$options = \get_option( 'irving_integrations' );
 
 	// When no option is passed, return all options for the integration.

--- a/tests/components/test-components.php
+++ b/tests/components/test-components.php
@@ -1433,6 +1433,8 @@ class Test_Components extends WP_UnitTestCase {
 	 * @group coral
 	 */
 	public function test_component_coral_comment_counts() {
+		// Mock integration to Coral.
+		update_option( 'irving_integrations', [ 'coral_url' => 'https://example.coral.test' ] );
 
 		$expected = $this->get_expected_component(
 			'irving/coral-comment-count',
@@ -1449,8 +1451,7 @@ class Test_Components extends WP_UnitTestCase {
 			'irving/coral-comment-count',
 			[
 				'config' => [
-					'embed_URL' => 'https://example.coral.test',
-					'post_id'   => self::$post_id,
+					'post_id' => self::$post_id,
 				],
 			]
 		);


### PR DESCRIPTION
Changes:

* Renames `WP_Irving\Integrations\get_option()` to `...\get_option_value()` to avoid collisions with the use of the WP `get_option()` function inside other files in the namespace.
* Always remove trailing slashes from the `embed_URL` value since it's added on the front end.