### PR TITLE
Integrations: Automatically hydrate irving/coral embed_url

### DIFF
--- a/inc/components/components/coral/component.php
+++ b/inc/components/components/coral/component.php
@@ -9,7 +9,21 @@
 
 namespace WP_Irving\Components;
 
+use WP_Irving\Integrations;
+
 /**
  * Register the component.
  */
-register_component_from_config( __DIR__ . '/component' );
+register_component_from_config(
+	__DIR__ . '/component',
+	[
+		'config_callback' => function ( $config ) {
+			return array_merge(
+				$config,
+				[
+					'embed_URL' => untrailingslashit( Integrations\get_option_value( 'coral', 'url' ) ),
+				]
+			);
+		},
+	]
+);

--- a/tests/components/test-components.php
+++ b/tests/components/test-components.php
@@ -1427,6 +1427,29 @@ class Test_Components extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test irving/coral
+	 *
+	 * @group coral
+	 */
+	public function test_component_coral() {
+		// Mock integration to Coral.
+		update_option( 'irving_integrations', [ 'coral_url' => 'https://example.coral.test' ] );
+
+		$expected = $this->get_expected_component(
+			'irving/coral',
+			[
+				'config' => [
+					'embedUrl' => 'https://example.coral.test',
+				],
+			]
+		);
+
+		$component = new Component( 'irving/coral' );
+
+		$this->assertComponentEquals( $expected, $component );
+	}
+
+	/**
 	 * Test irving/coral-comment-counts component.
 	 *
 	 * @group core-components


### PR DESCRIPTION
This adds a config_callback to the `irving/coral` component that gets
the option value for the embed_url from the Integrations settings.

Adds unit test for the component.