### PR TITLE
Add share links config to social sharing component

### DIFF
--- a/inc/components/components/post-social-sharing/component.json
+++ b/inc/components/components/post-social-sharing/component.json
@@ -23,6 +23,10 @@
       ],
       "type": "array"
     },
+    "platform_share_links": {
+      "default": [],
+      "type": "array"
+    },
     "post_id": {
       "default": 0,
       "type": "int"

--- a/tests/components/test-components.php
+++ b/tests/components/test-components.php
@@ -725,9 +725,9 @@ class Test_Components extends WP_UnitTestCase {
 			[
 				'_alias' => 'irving/social-sharing',
 				'config' => [
-					'description' => $this->get_post_excerpt(),
-					'imageUrl'    => $this->get_attachment_url(),
-					'platforms'   => [
+					'description'        => $this->get_post_excerpt(),
+					'imageUrl'           => $this->get_attachment_url(),
+					'platforms'          => [
 						'email',
 						'facebook',
 						'linkedin',
@@ -736,9 +736,10 @@ class Test_Components extends WP_UnitTestCase {
 						'twitter',
 						'whatsapp',
 					],
-					'postId'      => $this->get_post_id(),
-					'title'       => get_the_title( $this->get_post_id() ),
-					'url'         => get_the_permalink( $this->get_post_id() ),
+					'platformShareLinks' => [],
+					'postId'             => $this->get_post_id(),
+					'title'              => get_the_title( $this->get_post_id() ),
+					'url'                => get_the_permalink( $this->get_post_id() ),
 				],
 			]
 		);


### PR DESCRIPTION
Related Irving Core PR: https://github.com/alleyinteractive/irving/pull/285

This allows for custom share links/platforms to be passed to the front end.