### PR TITLE
Improvements to <head> management, and block library support.

### DIFF
--- a/inc/components/components/head/component.json
+++ b/inc/components/components/head/component.json
@@ -1,4 +1,11 @@
 {
     "name": "irving/head",
-    "description": "HTML <head> management."
+    "description": "HTML <head> management.",
+    "config": {
+      "context": {
+        "default": "page",
+        "description": "Context of the WP Irving component endpoint.",
+        "type": "string"
+      }
+    }
 }

--- a/inc/components/components/post-content/component.json
+++ b/inc/components/components/post-content/component.json
@@ -3,6 +3,28 @@
   "_alias": "irving/text",
   "category": "Post",
   "description": "Get the post content.",
+  "config": {
+    "content": {
+      "default": "",
+      "type": "string"
+    },
+    "html": {
+      "default": true,
+      "type": "bool"
+    },
+    "oembed": {
+      "default": true,
+      "type": "bool"
+    },
+    "style": {
+      "default": [],
+      "type": "array"
+    },
+    "tag": {
+      "default": "span",
+      "type": "string"
+    }
+  },
   "use_context": {
     "irving/post_id": "post_id"
   }

--- a/inc/components/components/post-content/component.json
+++ b/inc/components/components/post-content/component.json
@@ -21,7 +21,7 @@
       "type": "array"
     },
     "tag": {
-      "default": "span",
+      "default": "div",
       "type": "string"
     }
   },

--- a/inc/components/components/post-content/component.php
+++ b/inc/components/components/post-content/component.php
@@ -31,11 +31,7 @@ register_component_from_config(
 			 *
 			 * @see https://github.com/WordPress/gutenberg/blob/30cd85aebe14eee995e3162f09d31f4d4786f101/packages/block-library/src/post-content/index.php#L23
 			 */
-			$content = apply_filters( 'the_content', str_replace( ']]>', ']]&gt;', get_the_content( null, false, $post_id ) ) ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
-
-			$config['content'] = $content;
-			$config['html']    = true;
-			$config['oembed']  = true;
+			$config['content'] = apply_filters( 'the_content', str_replace( ']]>', ']]&gt;', get_the_content( null, false, $post_id ) ) ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 
 			return $config;
 		},

--- a/inc/integrations/class-yoast.php
+++ b/inc/integrations/class-yoast.php
@@ -29,36 +29,7 @@ class Yoast {
 		if ( ! is_admin() ) {
 			// Parse Yoast's head markup and inject it into the Head component.
 			add_filter( 'wp_irving_component_children', [ $this, 'inject_yoast_tags_into_head_children' ], 10, 3 );
-			add_filter( 'wp_irving_integrations_config', [ $this, 'inject_yoast_schema_into_integrations_config' ] );
 		}
-	}
-
-	/**
-	 * Parse Yoast's head markup and inject the `application/ld+json` schema into
-	 * the integrations config to be automatically managed on the front-end.
-	 *
-	 * @param array $config The current configuration.
-	 * @return array The updated configuration.
-	 */
-	public function inject_yoast_schema_into_integrations_config( array $config ): array {
-
-		// Parse Yoast's head markup for the appliction/ld+json script tag.
-		preg_match(
-			'/<script type="application\/ld\+json"[^>]+>(.+)<\/script>/',
-			$this->get_yoasts_head_markup(),
-			$matches
-		);
-
-		// Set the content. The match at the `0` index represents the full match, with
-		// the match at the `1` index representing the target group.
-		$content = $matches[1] ?? '';
-
-		// If the content exists, add it to the configuration array.
-		if ( ! empty( $content ) ) {
-			$config['yoast_schema'] = [ 'content' => $content ];
-		}
-
-		return $config;
 	}
 
 	/**
@@ -81,7 +52,7 @@ class Yoast {
 
 		return array_merge(
 			$children,
-			Components\html_to_components( $this->get_yoasts_head_markup(), [ 'title', 'meta', 'link' ] )
+			Components\html_to_components( $this->get_yoasts_head_markup(), [ 'title', 'meta', 'link', 'script' ] )
 		);
 	}
 

--- a/inc/templates/namespace.php
+++ b/inc/templates/namespace.php
@@ -19,6 +19,7 @@ use WP_REST_Request;
 function bootstrap() {
 	add_filter( 'wp_irving_components_route', __NAMESPACE__ . '\\load_template', 10, 6 );
 	add_action( 'wp_irving_component_children', __NAMESPACE__ . '\\inject_favicon', 10, 3 );
+	add_action( 'wp_irving_component_children', __NAMESPACE__ . '\\inject_custom_css', 10, 3 );
 	add_action( 'wp_irving_component_children', __NAMESPACE__ . '\\inject_block_library_styles', 10, 3 );
 }
 
@@ -644,6 +645,46 @@ function inject_favicon( array $children, array $config, string $name ): array {
 }
 
 /**
+ * Inject the custom css styles into the <head> component.
+ *
+ * @param array  $children Children for this component.
+ * @param array  $config   Config for this component.
+ * @param string $name     Name of this component.
+ * @return array
+ */
+function inject_custom_css( array $children, array $config, string $name ): array {
+	// Ony run this action on the `irving/head` in a `page` context.
+	if (
+		'irving/head' !== $name
+		|| 'page' !== ( $config['context'] ?? 'page' )
+	) {
+		return $children;
+	}
+
+	// Check for existence of custom css.
+	$custom_css = wp_get_custom_css();
+	if ( empty( $custom_css ) ) {
+		return $children;
+	}
+
+	// Inject the custom css.
+	$children[] = new Components\Component(
+		'style',
+		[
+			'config'   => [
+				'id'   => 'wp-custom-css',
+				'type' => 'text/css',
+			],
+			'children' => [
+				wp_get_custom_css(),
+			],
+		]
+	);
+
+	return $children;
+}
+
+/**
  * Inject the block-library styles into the <head> component.
  *
  * @param array  $children Children for this component.
@@ -652,21 +693,31 @@ function inject_favicon( array $children, array $config, string $name ): array {
  * @return array
  */
 function inject_block_library_styles( array $children, array $config, string $name ): array {
-	// Ony run this action on the `irving/head` in a `defaults` context.
+	// Ony run this action on the `irving/head` in a `page` context.
 	if (
 		'irving/head' !== $name
-		|| 'site' !== ( $config['context'] ?? 'page' )
+		|| 'page' !== ( $config['context'] ?? 'page' )
 	) {
 		return $children;
 	}
 
+	// Ensure the block library is enqueued.
+	global $wp_styles;
+	if ( ! isset( $wp_styles->registered['wp-block-library'] ) ) {
+		return $children;
+	}
+
 	// Inject the block library styles.
-	// @todo Only do this if Gutenberg is enabled.
 	$children[] = new Components\Component(
 		'link',
 		[
 			'config' => [
-				'href'  => 'https://jfc.alley.test/defector/wp-includes/css/dist/block-library/style.min.css?ver=5.5',
+				'href'  => sprintf(
+					'%1$s%2$s?ver=%3$s',
+					$wp_styles->base_url,
+					$wp_styles->registered['wp-block-library']->src,
+					$wp_styles->default_version
+				),
 				'id'    => 'wp-block-library-css',
 				'media' => 'all',
 				'rel'   => 'stylesheet',

--- a/inc/templates/namespace.php
+++ b/inc/templates/namespace.php
@@ -19,6 +19,7 @@ use WP_REST_Request;
 function bootstrap() {
 	add_filter( 'wp_irving_components_route', __NAMESPACE__ . '\\load_template', 10, 6 );
 	add_action( 'wp_irving_component_children', __NAMESPACE__ . '\\inject_favicon', 10, 3 );
+	add_action( 'wp_irving_component_children', __NAMESPACE__ . '\\inject_block_library_styles', 10, 3 );
 }
 
 /**
@@ -504,7 +505,7 @@ function setup_head(
 				'irving/head',
 				[
 					'config' => [
-						'context' => 'defaults',
+						'context' => 'site',
 					],
 				]
 			)
@@ -640,4 +641,39 @@ function inject_favicon( array $children, array $config, string $name ): array {
 		$children,
 		Components\html_to_components( get_favicon_markup(), [ 'link', 'meta' ] )
 	);
+}
+
+/**
+ * Inject the block-library styles into the <head> component.
+ *
+ * @param array  $children Children for this component.
+ * @param array  $config   Config for this component.
+ * @param string $name     Name of this component.
+ * @return array
+ */
+function inject_block_library_styles( array $children, array $config, string $name ): array {
+	// Ony run this action on the `irving/head` in a `defaults` context.
+	if (
+		'irving/head' !== $name
+		|| 'site' !== ( $config['context'] ?? 'page' )
+	) {
+		return $children;
+	}
+
+	// Inject the block library styles.
+	// @todo Only do this if Gutenberg is enabled.
+	$children[] = new Components\Component(
+		'link',
+		[
+			'config' => [
+				'href'  => 'https://jfc.alley.test/defector/wp-includes/css/dist/block-library/style.min.css?ver=5.5',
+				'id'    => 'wp-block-library-css',
+				'media' => 'all',
+				'rel'   => 'stylesheet',
+				'type'  => 'text/css',
+			],
+		]
+	);
+
+	return $children;
 }

--- a/tests/components/test-components.php
+++ b/tests/components/test-components.php
@@ -367,6 +367,8 @@ class Test_Components extends WP_UnitTestCase {
 				'html'         => true,
 				'oembed'       => true,
 				'postId'       => $this->get_post_id(),
+				'style'        => [],
+				'tag'          => 'span',
 				'themeName'    => 'default',
 				'themeOptions' => [ 'default' ],
 			],

--- a/tests/components/test-components.php
+++ b/tests/components/test-components.php
@@ -368,7 +368,7 @@ class Test_Components extends WP_UnitTestCase {
 				'oembed'       => true,
 				'postId'       => $this->get_post_id(),
 				'style'        => [],
-				'tag'          => 'span',
+				'tag'          => 'div',
 				'themeName'    => 'default',
 				'themeOptions' => [ 'default' ],
 			],

--- a/tests/components/test-html-markup.php
+++ b/tests/components/test-html-markup.php
@@ -127,6 +127,26 @@ class Test_HTML_Markup extends WP_UnitTestCase {
 				'<a> markup not parsed correctly.',
 			],
 			[
+				// Test a <script> element.
+				'<script type="application/ld+json" class="yoast-schema-graph">{"@context":"https://schema.org","@graph":[{"@type":"WebSite","@id":"https://irving.alley.test/#website","url":"https://irving.alley.test/","name":"Irving Development","description":"Just another WordPress site","potentialAction":[{"@type":"SearchAction","target":"https://irving.alley.test/?s={search_term_string}","query-input":"required name=search_term_string"}],"inLanguage":"en-US"},{"@type":"CollectionPage","@id":"https://irving.alley.test/#webpage","url":"https://irving.alley.test/","name":"Irving Development - Just another WordPress site","isPartOf":{"@id":"https://irving.alley.test/#website"},"description":"Just another WordPress site","inLanguage":"en-US"}]}</script>',
+				[ 'script' ],
+				[
+					new Component(
+						'script',
+						[
+							'config'   => [
+								'type'  => 'application/ld+json',
+								'class' => 'yoast-schema-graph',
+							],
+							'children' => [
+								'{"@context":"https://schema.org","@graph":[{"@type":"WebSite","@id":"https://irving.alley.test/#website","url":"https://irving.alley.test/","name":"Irving Development","description":"Just another WordPress site","potentialAction":[{"@type":"SearchAction","target":"https://irving.alley.test/?s={search_term_string}","query-input":"required name=search_term_string"}],"inLanguage":"en-US"},{"@type":"CollectionPage","@id":"https://irving.alley.test/#webpage","url":"https://irving.alley.test/","name":"Irving Development - Just another WordPress site","isPartOf":{"@id":"https://irving.alley.test/#website"},"description":"Just another WordPress site","inLanguage":"en-US"}]}',
+							],
+						]
+					),
+				],
+				'<a> markup not parsed correctly.',
+			],
+			[
 				// Test a search for <link> when none exist.
 				'<meta name="description" content="Hello World" />',
 				[ 'link' ],
@@ -163,7 +183,7 @@ class Test_HTML_Markup extends WP_UnitTestCase {
 			[
 				// Test multiple tags.
 				$this->example_markup,
-				[ 'title', 'meta', 'link' ],
+				[ 'title', 'meta', 'link', 'script' ],
 				[
 					new Component(
 						'title',
@@ -215,6 +235,18 @@ class Test_HTML_Markup extends WP_UnitTestCase {
 							'config' => [
 								'href' => 'https://irving.alley.test/',
 								'rel'  => 'canonical',
+							],
+						]
+					),
+					new Component(
+						'script',
+						[
+							'config'   => [
+								'type'  => 'application/ld+json',
+								'class' => 'yoast-schema-graph',
+							],
+							'children' => [
+								'{"@context":"https://schema.org","@graph":[{"@type":"WebSite","@id":"https://irving.alley.test/#website","url":"https://irving.alley.test/","name":"Irving Development","description":"Just another WordPress site","potentialAction":[{"@type":"SearchAction","target":"https://irving.alley.test/?s={search_term_string}","query-input":"required name=search_term_string"}],"inLanguage":"en-US"},{"@type":"CollectionPage","@id":"https://irving.alley.test/#webpage","url":"https://irving.alley.test/","name":"Irving Development - Just another WordPress site","isPartOf":{"@id":"https://irving.alley.test/#website"},"description":"Just another WordPress site","inLanguage":"en-US"}]}',
 							],
 						]
 					),

--- a/tests/templates/test-head-management.php
+++ b/tests/templates/test-head-management.php
@@ -119,7 +119,7 @@ class Test_Head_Management extends WP_UnitTestCase {
 				'irving/head',
 				[
 					'config' => [
-						'context' => 'defaults',
+						'context' => 'site',
 					],
 				]
 			),
@@ -178,14 +178,14 @@ class Test_Head_Management extends WP_UnitTestCase {
 					'irving/head',
 					[
 						'config'   => [
-							'context' => 'defaults',
+							'context' => 'site',
 						],
 						'children' => [
 							new Component(
 								'meta',
 								[
 									'config' => [
-										'context' => 'defaults',
+										'context' => 'site',
 									],
 								]
 							),


### PR DESCRIPTION
## Summary
Updates to the WP Irving plugin to better support parts of <head> management, block library, and Yoast integration.

## Notes for reviewers
This PR was developed is in conjunction with https://github.com/alleyinteractive/irving/pull/286

This version will break any version of Irving without the above PR.

## Changelog entries
* **Added**: Block library styles will automatically enqueue to Irving frontend.
* **Added**: Support for the customizer's custom css.
* **Changed**: Updated `irving/head` component to include a `context` prop.
* **Changed**: Updated `irving/post-content` component to include the same props as `irving/text`, and enable html and oembed by default via the JSON config, rather than toggling via the config callback.
* **Changed**: Update the Yoast integration to pass the schema iva <head> rather than handling separately with an integration.

## Ticket(s)
* https://alleyinteractive.atlassian.net/browse/IRV-406