### PR TITLE
Add `post_ids_to_skip` config to the `irving/post-list` component.

### DIFF
--- a/inc/components/components/post-list/component.json
+++ b/inc/components/components/post-list/component.json
@@ -13,6 +13,7 @@
       "type": "array"
     },
     "post_ids_to_skip": {
+      "hidden": true,
       "default": [],
       "type": "array"
     },

--- a/inc/components/components/post-list/component.json
+++ b/inc/components/components/post-list/component.json
@@ -12,6 +12,10 @@
       "hidden": true,
       "type": "array"
     },
+    "post_ids_to_skip": {
+      "default": [],
+      "type": "array"
+    },
     "wp_query": {
       "hidden": true,
       "type": "object"

--- a/inc/components/components/post-list/component.php
+++ b/inc/components/components/post-list/component.php
@@ -66,8 +66,6 @@ register_component_from_config(
 			$post_ids_to_skip = (array) ( $config['post_ids_to_skip'] ?? [] );
 			$post_ids         = array_values( array_diff( $post_ids, $post_ids_to_skip ) );
 
-			// print_r($post_ids); die();
-
 			$children = array_map(
 				function ( $post_id, $index ) use ( $templates ) {
 
@@ -89,8 +87,6 @@ register_component_from_config(
 				$post_ids,
 				array_keys( $post_ids )
 			);
-
-			// print_r($children); die();
 
 			// Inject interstitals.
 			if ( ! empty( $templates['interstitials'] ) ) {

--- a/inc/components/components/post-list/component.php
+++ b/inc/components/components/post-list/component.php
@@ -63,6 +63,11 @@ register_component_from_config(
 			// Add the current $post_ids to the list of used ids.
 			post_list_get_and_add_used_post_ids( $post_ids );
 
+			$post_ids_to_skip = (array) ( $config['post_ids_to_skip'] ?? [] );
+			$post_ids         = array_values( array_diff( $post_ids, $post_ids_to_skip ) );
+
+			// print_r($post_ids); die();
+
 			$children = array_map(
 				function ( $post_id, $index ) use ( $templates ) {
 
@@ -84,6 +89,8 @@ register_component_from_config(
 				$post_ids,
 				array_keys( $post_ids )
 			);
+
+			// print_r($children); die();
 
 			// Inject interstitals.
 			if ( ! empty( $templates['interstitials'] ) ) {


### PR DESCRIPTION
## Summary
Adds a `post_ids_to_skip` config array to the `irving/post-list` component, giving post lists an easy way to hide post IDs that are in the WP_Query object, but shouldn't be displayed.

This allows us to work around limitations with WP_Query and how WordPress builds them.

## Notes for reviewers
None.

## Changelog entries
* **Added**: A `post_ids_to_skip` config array to `irving/pots-list`.