### PR TITLE
Add image performance enhancements in irving/post-featured-image

### DIFF
--- a/inc/components/components/image/component.json
+++ b/inc/components/components/image/component.json
@@ -48,6 +48,10 @@
       "description": "Display meta.",
       "type": "bool"
     },
+    "sizes": {
+      "description": "An image sizes attribute string.",
+      "type": "string"
+    },
     "size": {
       "default": "full",
       "description": "A WordPress image size to use. Default 'full'.",

--- a/inc/components/components/image/component.php
+++ b/inc/components/components/image/component.php
@@ -24,14 +24,14 @@ register_component_from_config(
 
 			// Hydrate data from an ID.
 			if ( isset( $config['id'] ) ) {
-				$atts = wp_get_attachment_image_src( $config['id'], $config['size'] );
+				$image_atts = get_image_component_attributes( $config['id'], $config['size'] );
 
-				$config['src']    = $atts[0];
-				$config['width']  = $atts[1];
-				$config['height'] = $atts[2];
-				$config['alt']    = $config['alt'] ?? (string) get_post_meta( $config['id'], '_wp_attachment_image_alt', true );
-				$config['sizes']  = wp_get_attachment_image_sizes( $config['id'], $config['size'] );
-				$config['srcset'] = wp_get_attachment_image_srcset( $config['id'], $config['size'] );
+				// Override empty or unset config values with WP data.
+				foreach ( $image_atts as $key => $value ) {
+					if ( ! isset( $config[ $key ] ) || empty( $config[ $key ] ) ) {
+						$config[ $key ] = $value;
+					}
+				}
 			}
 
 			return $config;

--- a/inc/components/components/post-featured-image/component.json
+++ b/inc/components/components/post-featured-image/component.json
@@ -2,6 +2,76 @@
   "name": "irving/post-featured-image",
   "_alias": "irving/image",
   "description": "Get the post featured image.",
+  "config": {
+    "allow_upscaling": {
+      "default": false,
+      "description": "Allow an image to be scaled to larger than its actual width.",
+      "type": "bool"
+    },
+    "alt": {
+      "description": "Value of the alt attribute.",
+      "type": "string"
+    },
+    "aspect_ratio": {
+      "description": "Optional. Aspect ratio for the image to conform to. Can be a float (\"0.6667\"), a ratio (\"16 / 9\"), or a predfined ratio (\"square\").",
+      "type": "string"
+    },
+    "caption": {
+      "description": "Optional. Caption for the image.",
+      "default": "",
+      "type": "string"
+    },
+    "class_name": {
+      "description": "Optional. Classname.",
+      "type": "string"
+    },
+    "fallback_src": {
+      "description": "Optional. URL for the image source if \"src\" is not set.",
+      "type": "string"
+    },
+    "loading": {
+      "default": "lazy",
+      "description": "Lazy loading setting. Either \"eager\" or \"lazy\".",
+      "type": "string"
+    },
+    "object_fit": {
+      "default": "cover",
+      "description": "Object fit property.",
+      "type": "string"
+    },
+    "show_meta": {
+      "default": true,
+      "description": "Display meta.",
+      "type": "bool"
+    },
+    "size": {
+      "default": "full",
+      "description": "A WordPress image size to use. Default 'full'.",
+      "type": "string",
+      "hidden": true
+    },
+    "sizes": {
+      "description": "An image sizes attribute string.",
+      "type": "string"
+    },
+    "src": {
+      "description": "Optional. URL for the image source.",
+      "type": "string"
+    },
+    "srcset": {
+      "description":"A source list string for delivering responsive images.",
+      "type": "string"
+    },
+    "style": {
+      "default": [],
+      "type": "array"
+    },
+    "query_args": {
+      "description": "A set of query args to add to the URL string of the src.",
+      "default": [],
+      "type": "array"
+    }
+  },
   "use_context": {
     "irving/post_id": "post_id"
   }

--- a/inc/components/components/post-featured-image/component.php
+++ b/inc/components/components/post-featured-image/component.php
@@ -28,15 +28,20 @@ register_component_from_config(
 
 			$thumbnail_id = get_post_thumbnail_id( $post_id );
 
-			return array_merge(
-				$config,
-				[
-					'alt'     => get_image_alt( $thumbnail_id ),
-					'caption' => wp_get_attachment_caption( $thumbnail_id ),
-					'credit'  => get_post_meta( $thumbnail_id, 'credit', true ),
-					'src'     => get_the_post_thumbnail_url( $post_id ),
-				]
-			);
+			$config['caption'] = wp_get_attachment_caption( $thumbnail_id );
+			$config['credit']  = get_post_meta( $thumbnail_id, 'credit', true );
+
+			$image_atts = get_image_component_attributes( $thumbnail_id, $config['size'] );
+
+			// Override empty or unset config values with WP data.
+			foreach ( $image_atts as $key => $value ) {
+				if ( ! isset( $config[ $key ] ) || empty( $config[ $key ] ) ) {
+					$config[ $key ] = $value;
+				}
+			}
+
+
+			return $config;
 		},
 	]
 );

--- a/inc/components/namespace.php
+++ b/inc/components/namespace.php
@@ -223,3 +223,28 @@ function html_to_components( string $markup, array $tags ): array {
 
 	return $components;
 }
+
+/**
+ * Helper to get image attributes for a component.
+ *
+ * @param int    $attachment_id An attachment ID.
+ * @param string $size          Optional. The intermediate image size to use. Default 'full'.
+ * @return array An array of image configuration attributes.
+ */
+function get_image_component_attributes( int $attachment_id, string $size = 'full' ): array {
+	// Bail early if this isn't an attachment.
+	if ( ! wp_attachment_is_image( $attachment_id ) ) {
+		return [];
+	}
+
+	$atts = wp_get_attachment_image_src( $attachment_id, $size );
+
+	return [
+		'src'    => $atts[0],
+		'width'  => $atts[1],
+		'height' => $atts[2],
+		'alt'    => $config['alt'] ?? (string) get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ),
+		'sizes'  => wp_get_attachment_image_sizes( $attachment_id, $size ),
+		'srcset' => wp_get_attachment_image_srcset( $attachment_id, $size ),
+	];
+}

--- a/tests/components/test-components.php
+++ b/tests/components/test-components.php
@@ -77,9 +77,7 @@ class Test_Components extends WP_UnitTestCase {
 	 * @return string attachment URL.
 	 */
 	public function get_attachment_url() {
-		$uploads_dir = wp_get_upload_dir();
-
-		return trailingslashit( $uploads_dir['url'] ) . 'test-image.jpg';
+		return wp_get_attachment_image_url( $this->get_attachment_id() );
 	}
 
 	/**
@@ -159,14 +157,16 @@ class Test_Components extends WP_UnitTestCase {
 	 * @param WP_UnitTest_Factory $factory Factory instance.
 	 */
 	public static function wpSetupBeforeClass( $factory ) {
-		// Test image.
-		self::$attachment_id = $factory->attachment->create_object(
-			'test-image.jpg',
-			null,
+		// Path to a test image.
+		$filename = dirname( __DIR__, ) . '/data/images/test-image-large.png';
+		// Create attachment.
+		self::$attachment_id = $factory->attachment->create_upload_object( $filename );
+
+		// Set post data.
+		wp_update_post(
 			[
-				'post_mime_type' => 'image/jpeg',
-				'post_type'      => 'attachment',
-				'post_excerpt'   => 'Test caption text.',
+				'ID'           => self::$attachment_id,
+				'post_excerpt' => 'Test caption text.',
 			]
 		);
 
@@ -291,7 +291,7 @@ class Test_Components extends WP_UnitTestCase {
 	/**
 	 * Test the image component with defaults.
 	 *
-	 * @group image
+	 * @group images
 	 */
 	public function test_component_image() {
 		$expected = $this->get_expected_component(
@@ -328,12 +328,10 @@ class Test_Components extends WP_UnitTestCase {
 	/**
 	 * Test the image component when passing an attachment ID.
 	 *
-	 * @group image
+	 * @group images
 	 */
 	public function test_component_image_from_attachment_id() {
-		// Make an image using test data from the WP Unit Test suite.
-		$filename = dirname( __DIR__, ) . '/data/images/test-image-large.png';
-		$id       = self::factory()->attachment->create_upload_object( $filename );
+		$id = $this->get_attachment_id();
 
 		$image_attr = wp_get_attachment_image_src( $id, 'full' );
 
@@ -341,7 +339,7 @@ class Test_Components extends WP_UnitTestCase {
 			'irving/image',
 			[
 				'config' => [
-					'alt'            => '',
+					'alt'            => 'Test alt text.',
 					'allowUpscaling' => false,
 					'caption'        => '',
 					'height'         => $image_attr[2],
@@ -500,21 +498,34 @@ class Test_Components extends WP_UnitTestCase {
 	 * Test irving/post-featured-image component.
 	 *
 	 * @group core-components
+	 * @group images
 	 */
 	public function test_component_post_featured_image() {
 		$this->go_to( '?p=' . $this->get_post_id() );
+
+		$image_attr = wp_get_attachment_image_src( $this->get_attachment_id(), 'full' );
 
 		$expected = [
 			'name'     => 'irving/post-featured-image',
 			'_alias'   => 'irving/image',
 			'config'   => (object) [
-				'alt'          => 'Test alt text.',
-				'caption'      => 'Test caption text.',
-				'credit'       => 'Test credit text.',
-				'src'          => $this->get_attachment_url(),
-				'postId'       => $this->get_post_id(),
-				'themeName'    => 'default',
-				'themeOptions' => [ 'default' ],
+				'alt'            => 'Test alt text.',
+				'allowUpscaling' => false,
+				'caption'        => 'Test caption text.',
+				'credit'         => 'Test credit text.',
+				'height'         => $image_attr[2],
+				'loading'        => 'lazy',
+				'src'            => $image_attr[0],
+				'objectFit'      => 'cover',
+				'postId'         => $this->get_post_id(),
+				'themeName'      => 'default',
+				'themeOptions'   => [ 'default' ],
+				'width'          => $image_attr[1],
+				'srcset'         => wp_get_attachment_image_srcset( $this->get_attachment_id(), 'full' ),
+				'sizes'          => wp_get_attachment_image_sizes( $this->get_attachment_id(), 'full' ),
+				'showMeta'       => true,
+				'style'          => [],
+				'queryArgs'      => [],
 			],
 			'children' => [],
 		];
@@ -528,9 +539,12 @@ class Test_Components extends WP_UnitTestCase {
 	 * Test irving/post-featured-media component.
 	 *
 	 * @group core-components
+	 * @group images
 	 */
 	public function test_component_post_featured_media() {
 		$this->go_to( '?p=' . $this->get_post_id() );
+
+		$image_attr = wp_get_attachment_image_src( $this->get_attachment_id(), 'full' );
 
 		$expected = [
 			'name'     => 'irving/post-featured-media',
@@ -548,13 +562,23 @@ class Test_Components extends WP_UnitTestCase {
 					'name'     => 'irving/post-featured-image',
 					'_alias'   => 'irving/image',
 					'config'   => (object) [
-						'alt'          => 'Test alt text.',
-						'caption'      => 'Test caption text.',
-						'credit'       => 'Test credit text.',
-						'src'          => $this->get_attachment_url(),
-						'postId'       => $this->get_post_id(),
-						'themeName'    => 'default',
-						'themeOptions' => [ 'default' ],
+						'alt'            => 'Test alt text.',
+						'allowUpscaling' => false,
+						'caption'        => 'Test caption text.',
+						'credit'         => 'Test credit text.',
+						'height'         => $image_attr[2],
+						'loading'        => 'lazy',
+						'src'            => $image_attr[0],
+						'objectFit'      => 'cover',
+						'postId'         => $this->get_post_id(),
+						'themeName'      => 'default',
+						'themeOptions'   => [ 'default' ],
+						'width'          => $image_attr[1],
+						'srcset'         => wp_get_attachment_image_srcset( $this->get_attachment_id(), 'full' ),
+						'sizes'          => wp_get_attachment_image_sizes( $this->get_attachment_id(), 'full' ),
+						'showMeta'       => true,
+						'style'          => [],
+						'queryArgs'      => [],
 					],
 					'children' => [],
 				],

--- a/tests/components/test-components.php
+++ b/tests/components/test-components.php
@@ -77,7 +77,7 @@ class Test_Components extends WP_UnitTestCase {
 	 * @return string attachment URL.
 	 */
 	public function get_attachment_url() {
-		return wp_get_attachment_image_url( $this->get_attachment_id() );
+		return wp_get_attachment_image_url( $this->get_attachment_id(), 'original' );
 	}
 
 	/**


### PR DESCRIPTION
This updates the post-featured-image component to support the enhanced hydration abilities of the image component.

* Adds: `WP_Irving\Components\get_image_component_attributes()` function for getting common image attributes from WordPress.
* Updates: config.json and config_callback for post-featured-image to match the image component.
* Adds: Support for manually setting a `sizes` attribute to both components.
* Updates: Unit tests.