### PR TITLE
DEF-36: Add filterable event for WP Irving to populate GTM data layer

### DIFF
--- a/inc/integrations/class-google-tag-manager.php
+++ b/inc/integrations/class-google-tag-manager.php
@@ -111,7 +111,7 @@ class Google_Tag_Manager {
 		$gtm_key = $this->options[ $this->option_key ]['container_id'] ?? '';
 
 		?>
-		<input type="text" name="irving_integrations[<?php echo esc_attr( 'gtm_container_id' ); ?>]" value="<?php echo esc_attr( $gtm_key ); ?>" />
+			<input type="text" name="irving_integrations[<?php echo esc_attr( 'gtm_container_id' ); ?>]" value="<?php echo esc_attr( $gtm_key ); ?>" />
 		<?php
 	}
 }

--- a/inc/integrations/class-google-tag-manager.php
+++ b/inc/integrations/class-google-tag-manager.php
@@ -71,7 +71,7 @@ class Google_Tag_Manager {
 		 *
 		 * @param array $data_layer The data layer arguments for GTM.
 		 */
-		$data_layer = apply_filters( 'wp-irving-gtm-data-layer', $data_layer );
+		$data_layer = apply_filters( 'wp_irving_gtm_data_layer', $data_layer );
 
 		$children[] = new Component(
 			'script',

--- a/inc/integrations/class-google-tag-manager.php
+++ b/inc/integrations/class-google-tag-manager.php
@@ -81,6 +81,7 @@ class Google_Tag_Manager {
 					'type' => 'text/javascript',
 				],
 				'children' => [
+					'window.dataLayer = window.dataLayer ?? [];',
 					'window.dataLayer.push(' . wp_json_encode( $data_layer ) . ');',
 				],
 			]

--- a/inc/integrations/class-integrations-manager.php
+++ b/inc/integrations/class-integrations-manager.php
@@ -63,7 +63,7 @@ class Integrations_Manager {
 				case strpos( $key, 'ga_' ) !== false:
 					$formatted_options['google_analytics'][ str_replace( 'ga_', '', $key ) ] = $val;
 					break;
-				// Build the contig array for GTM.
+				// Build the config array for GTM.
 				case strpos( $key, 'gtm_' ) !== false:
 					$formatted_options['google_tag_manager'][ str_replace( 'gtm_', '', $key ) ] = $val;
 					break;


### PR DESCRIPTION
Related to https://alleyinteractive.atlassian.net/browse/DEF-36

*Adds a script to the page `head` which passes WP info to GTM data layer*
Uses native Irving functionality to ensure each page head has a component with page info.