### PR TITLE
Add initial data layer to GTM integrations.

### DIFF
--- a/inc/integrations/class-google-tag-manager.php
+++ b/inc/integrations/class-google-tag-manager.php
@@ -30,7 +30,7 @@ class Google_Tag_Manager {
 	private $options;
 
 	/**
-	 * Setup the singleton. Validate JWT is installed, and setup hooks.
+	 * Setup the singleton.
 	 */
 	public function setup() {
 		// Retrieve any existing integrations options.
@@ -39,7 +39,7 @@ class Google_Tag_Manager {
 		// Register settings fields for integrations.
 		add_action( 'admin_init', [ $this, 'register_settings_fields' ] );
 
-		// Filter the integrations manager to include our Pico props.
+		// Filter the integrations manager to include a data layer for GTM.
 		add_filter( 'wp_irving_integrations_option', [ $this, 'get_data_layer' ] );
 	}
 
@@ -76,11 +76,10 @@ class Google_Tag_Manager {
 	 * @return array An array of options.
 	 */
 	public function get_data_layer( $options ) {
-
 		$data_layer = apply_filters(
 			'wp_irving_gtm_data',
 			[
-				'title' => wp_title( null, false ),
+				'event' => 'irving.page',
 			]
 		);
 

--- a/inc/integrations/class-google-tag-manager.php
+++ b/inc/integrations/class-google-tag-manager.php
@@ -38,6 +38,9 @@ class Google_Tag_Manager {
 
 		// Register settings fields for integrations.
 		add_action( 'admin_init', [ $this, 'register_settings_fields' ] );
+
+		// Filter the integrations manager to include our Pico props.
+		add_filter( 'wp_irving_integrations_option', [ $this, 'get_data_layer' ] );
 	}
 
 	/**
@@ -64,5 +67,25 @@ class Google_Tag_Manager {
 		?>
 			<input type="text" name="irving_integrations[<?php echo esc_attr( 'gtm_container_id' ); ?>]" value="<?php echo esc_attr( $gtm_key ); ?>" />
 		<?php
+	}
+
+	/**
+	 * Get data layer info for a page load.
+	 *
+	 * @param array $options Array of integration options.
+	 * @return array An array of options.
+	 */
+	public function get_data_layer( $options ) {
+
+		$data_layer = apply_filters(
+			'wp_irving_gtm_data',
+			[
+				'title' => wp_title( null, false ),
+			]
+		);
+
+		$options[ $this->option_key] ['data_layer'] = (object) $data_layer;
+
+		return $options;
 	}
 }

--- a/inc/integrations/class-google-tag-manager.php
+++ b/inc/integrations/class-google-tag-manager.php
@@ -90,8 +90,10 @@ class Google_Tag_Manager {
 		$data_layer = apply_filters(
 			'wp_irving_gtm_data',
 			[
-				'title' => wp_title( null, false ),
-				'url'   => home_url( $path ),
+				'irving' => [
+					'title' => wp_title( null, false ),
+					'url'   => home_url( $path ),
+				],
 			]
 		);
 

--- a/inc/integrations/class-google-tag-manager.php
+++ b/inc/integrations/class-google-tag-manager.php
@@ -76,6 +76,11 @@ class Google_Tag_Manager {
 	 * @return array An array of options.
 	 */
 	public function get_data_layer( $options ) {
+		/**
+		 * Filters the data layer provided to GTM for each page.
+		 *
+		 * @param array $data_layer The data layer arguments for GTM.
+		 */
 		$data_layer = apply_filters(
 			'wp_irving_gtm_data',
 			[

--- a/inc/integrations/class-google-tag-manager.php
+++ b/inc/integrations/class-google-tag-manager.php
@@ -88,7 +88,7 @@ class Google_Tag_Manager {
 			]
 		);
 
-		$options[ $this->option_key] ['data_layer'] = (object) $data_layer;
+		$options[ $this->option_key ] ['data_layer'] = (object) $data_layer;
 
 		return $options;
 	}

--- a/inc/integrations/class-google-tag-manager.php
+++ b/inc/integrations/class-google-tag-manager.php
@@ -40,7 +40,9 @@ class Google_Tag_Manager {
 		add_action( 'admin_init', [ $this, 'register_settings_fields' ] );
 
 		// Filter the integrations manager to include a data layer for GTM.
-		add_filter( 'wp_irving_integrations_option', [ $this, 'get_data_layer' ] );
+		if ( ! is_admin() ) {
+			add_filter( 'wp_irving_integrations_option', [ $this, 'get_data_layer' ] );
+		}
 	}
 
 	/**
@@ -84,7 +86,8 @@ class Google_Tag_Manager {
 		$data_layer = apply_filters(
 			'wp_irving_gtm_data',
 			[
-				'event' => 'irving.page',
+				'title' => wp_title( null, false ),
+				'url'   => get_permalink() ?: home_url(),
 			]
 		);
 

--- a/inc/integrations/class-google-tag-manager.php
+++ b/inc/integrations/class-google-tag-manager.php
@@ -8,6 +8,7 @@
 namespace WP_Irving\Integrations;
 
 use WP_Irving\Singleton;
+use WP_Query;
 
 /**
  * Class to integrate Google Tag Manager with Irving.
@@ -41,7 +42,7 @@ class Google_Tag_Manager {
 
 		// Filter the integrations manager to include a data layer for GTM.
 		if ( ! is_admin() ) {
-			add_filter( 'wp_irving_integrations_option', [ $this, 'get_data_layer' ] );
+			add_filter( 'wp_irving_integrations_option', [ $this, 'get_data_layer' ], 10, 4 );
 		}
 	}
 
@@ -74,10 +75,13 @@ class Google_Tag_Manager {
 	/**
 	 * Get data layer info for a page load.
 	 *
-	 * @param array $options Array of integration options.
+	 * @param array    $options Array of integration options.
+	 * @param WP_Query $query   The current WP_Query object.
+	 * @param string   $context The context for this request.
+	 * @param string   $path    The path for this request.
 	 * @return array An array of options.
 	 */
-	public function get_data_layer( $options ) {
+	public function get_data_layer( array $options, WP_Query $query, string $context, string $path ): array {
 		/**
 		 * Filters the data layer provided to GTM for each page.
 		 *
@@ -87,7 +91,7 @@ class Google_Tag_Manager {
 			'wp_irving_gtm_data',
 			[
 				'title' => wp_title( null, false ),
-				'url'   => get_permalink() ?: home_url(),
+				'url'   => home_url( $path ),
 			]
 		);
 

--- a/inc/templates/namespace.php
+++ b/inc/templates/namespace.php
@@ -560,7 +560,7 @@ function setup_integrations( array $data, WP_Query $query, string $context, stri
 	 * by declaring this explicitly, we can make it more clear to developers
 	 * how to modify the value correctly.
 	 *
-	 * @param array $options Array of integration options.
+	 * @param array    $options Array of integration options.
 	 * @param WP_Query $query   The current WP_Query object.
 	 * @param string   $context The context for this request.
 	 * @param string   $path    The path for this request.

--- a/inc/templates/namespace.php
+++ b/inc/templates/namespace.php
@@ -535,9 +535,10 @@ function setup_head(
  * @param array    $data    Data object to be hydrated by templates.
  * @param WP_Query $query   The current WP_Query object.
  * @param string   $context The context for this request.
+ * @param string   $path    The path for this request.
  * @return array The updated endpoint data.
  */
-function setup_integrations( array $data, WP_Query $query, string $context ): array {
+function setup_integrations( array $data, WP_Query $query, string $context, string $path ): array {
 	// Inject the integrations manager into the defaults key.
 	if ( 'site' === $context ) {
 		array_push(
@@ -552,16 +553,21 @@ function setup_integrations( array $data, WP_Query $query, string $context ): ar
 	$options = (array) get_option( 'irving_integrations' );
 
 	/**
-	 * Modify the value stored in the `irving_integraionts` option before it's
+	 * Modify the value stored in the `irving_integrations` option before it's
 	 * used.
 	 *
 	 * This is essentially an alias for the `option_{$option}` filter, but
 	 * by declaring this explicitly, we can make it more clear to developers
 	 * how to modify the value correctly.
 	 *
-	 * @var array
+	 * @param array $options Array of integration options.
+	 * @param WP_Query $query   The current WP_Query object.
+	 * @param string   $context The context for this request.
+	 * @param string   $path    The path for this request.
 	 */
-	$options = array_filter( apply_filters( 'wp_irving_integrations_option', $options ) );
+	$options = array_filter(
+		apply_filters( 'wp_irving_integrations_option', $options, $query, $context, $path )
+	);
 
 	// Bail early if no options are present.
 	if ( empty( $options ) ) {


### PR DESCRIPTION
Adds: WP_Irving\Integrations\Google_Tag_Manager\get_data_layer() that injects a data layer object into all page responses.
Adds: Filter `wp_irving_gtm_data` to more easily allow filtering the GTM data.