### PR TITLE
Pico: Add support for using the staging widget URL

### DIFF
--- a/inc/integrations/class-pico.php
+++ b/inc/integrations/class-pico.php
@@ -166,6 +166,7 @@ class Pico {
 		$options['pico'] = [
 			'publisher_id' => Pico_Setup::get_publisher_id(),
 			'page_info'    => Pico_Widget::get_current_view_info(),
+			'widget_url'   => Pico_Setup::get_widget_endpoint(),
 		];
 
 		$tiers = Integrations\get_option_value( 'pico', 'tiers' );


### PR DESCRIPTION
This passes the widget endpoint URL as part of the integration response so that our front end application can swap out the location for the widget URL when switched into staging mode.