### PR TITLE
Bump version numbers for 0.5.0-alpha

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "wp-irving",
-  "version": "0.4.0",
   "description": "WordPress plugin to integrate with an Irving headless site.",
   "dependencies": {},
   "devDependencies": {

--- a/wp-irving.php
+++ b/wp-irving.php
@@ -6,7 +6,7 @@
  * Author URI:      https://alley.co
  * Text Domain:     wp-irving
  * Domain Path:     /languages
- * Version:         0.4.0
+ * Version:         0.5.0-alpha
  *
  * @package         WP_Irving
  */
@@ -15,7 +15,7 @@ namespace WP_Irving;
 
 define( 'WP_IRVING_PATH', dirname( __FILE__ ) );
 define( 'WP_IRVING_URL', plugin_dir_url( __FILE__ ) );
-define( 'WP_IRVING_VERSION', '0.4.0' );
+define( 'WP_IRVING_VERSION', '0.5.0-alpha' );
 
 // Flush rewrite rules when the plugin is activated or deactivated.
 register_activation_hook( __FILE__, 'flush_rewrite_rules' );


### PR DESCRIPTION
This bumps version numbers for the 0.5.0-alpha branch (i.e. master) and removes the version number from the package.json file, since we're not publishing to npm anyway.