### PR TITLE
Add options for camel casing keys

### DIFF
--- a/inc/components/class-component.php
+++ b/inc/components/class-component.php
@@ -921,12 +921,20 @@ class Component implements JsonSerializable {
 		// Loop through each key.
 		foreach ( $array as $key => $value ) {
 
-			if ( is_array( $value ) ) {
-				$value = self::camel_case_keys( $value );
+			// If it's an array, and its inner keys should be camel cased, recurse a level deeper.
+			if (
+				is_array( $value )
+				&& false !== ( $this->get_schema()[ $key ]['camel_case_inner_keys'] ?? true )
+			) {
+					$value = self::camel_case_keys( $value );
 			}
 
-			// Camel case the key.
-			$new_key = self::camel_case( $key );
+			// Camel case the key unless the schema explicitly states otherwise.
+			if ( false !== ( $this->get_schema()[ $key ]['camel_case_config_key'] ?? true ) ) {
+				$new_key = self::camel_case( $key );
+			} else {
+				$new_key = $key;
+			}
 
 			$camel_case_array[ $new_key ] = $value;
 		}

--- a/tests/components/test-class-component.php
+++ b/tests/components/test-class-component.php
@@ -590,6 +590,32 @@ class Test_Class_Component extends WP_UnitTestCase {
 				],
 				'Could not verify registered theme options.',
 			],
+			// Camel casing.
+			[
+				[ 'test/camel-case' ],
+				[
+					'name'     => 'test/camel-case',
+					'_alias'   => '',
+					'config'   => (object) [
+						'testCamelCaseConfigKeyTrue'       => '',
+						'test-camel-case-config-key-false' => '',
+						'testCamelCaseInnerKeysTrue'       => (object) [
+							'keyOne' => '',
+							'keyTwo' => '',
+						],
+						'testCamelCaseInnerKeysFalse'      => (object) [
+							'key-one' => '',
+							'key_two' => '',
+						],
+						'className'                        => '',
+						'style'                            => [],
+						'themeName'                        => 'default',
+						'themeOptions'                     => [ 'default' ],
+					],
+					'children' => [],
+				],
+				'Could not verify camel casing options worked.',
+			],
 		];
 	}
 

--- a/tests/components/test-components/alias.json
+++ b/tests/components/test-components/alias.json
@@ -1,4 +1,4 @@
 {
 	"name": "test/alias",
-	"_alias":  "test/component"
+	"_alias": "test/component"
 }

--- a/tests/components/test-components/camel-case.json
+++ b/tests/components/test-components/camel-case.json
@@ -1,0 +1,31 @@
+{
+  "name": "test/camel-case",
+  "config": {
+    "test-camel-case-config-key-true": {
+      "default": "",
+      "type": "string",
+      "camel_case_config_key": true
+    },
+    "test-camel-case-config-key-false": {
+      "default": "",
+      "type": "string",
+      "camel_case_config_key": false
+    },
+    "test-camel-case-inner-keys-true": {
+      "default": {
+        "key-one": "",
+        "key_two": ""
+      },
+      "type": "array",
+      "camel_case_inner_keys": true
+    },
+    "test-camel-case-inner-keys-false": {
+      "default": {
+        "key-one": "",
+        "key_two": ""
+      },
+      "type": "array",
+      "camel_case_inner_keys": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Adds two new options for the schema of a config, `camel_case_config_key` and `camel_case_inner_keys`.

* If not explicitly set, then they are assumed `true` and all keys and inner keys get camel cased.
* If `camel_case_config_key` is set to `false`, that config's key is not transformed to camel case.
* If `camel_case_inner_keys` is set to `false` and the config is an object, the inner keys are not transformed to camel case.

## Ticket
[IRV-707](https://alleyinteractive.atlassian.net/browse/IRV-707)