### PR TITLE
GTM: Escape the site path in the data layer.

### DIFF
--- a/inc/integrations/class-google-tag-manager.php
+++ b/inc/integrations/class-google-tag-manager.php
@@ -92,7 +92,7 @@ class Google_Tag_Manager {
 			[
 				'irving' => [
 					'title' => wp_title( null, false ),
-					'url'   => home_url( $path ),
+					'url'   => home_url( esc_url( $path ) ),
 				],
 			]
 		);


### PR DESCRIPTION
This patches a potential security issue if an XSS payload is added to the URL string.