### PR TITLE
Add support for nested site theme values

### DIFF
--- a/inc/templates/site-theme.php
+++ b/inc/templates/site-theme.php
@@ -81,6 +81,14 @@ function get_site_theme( $selector = '', $default = null ) {
 		$value = &$value[ $segment ];
 	}
 
+	// Support recursively getting a single value.
+	if ( is_string( $value ) ) {
+		do {
+			$default = $value;
+			$value   = get_site_theme( $value, $default );
+		} while ( $default !== $value );
+	}
+
 	// Return the value found at the final selector segment.
 	return $value;
 }

--- a/tests/test-site-theme.php
+++ b/tests/test-site-theme.php
@@ -34,6 +34,15 @@ class Test_Site_Theme extends WP_UnitTestCase {
 				'dark'  => '#DDDDDD',
 			],
 		],
+		'nested' => [
+			'first'  => 'colors.white',
+			'second' => [
+				'value' => 'colors.white',
+			],
+			'third'  => [
+				'value' => 'nested.second.value',
+			],
+		],
 	];
 
 	/**
@@ -138,6 +147,24 @@ class Test_Site_Theme extends WP_UnitTestCase {
 				'Hello World',
 				'Hello World',
 				'`Hello World` not returned as default for selector that does not exist.',
+			],
+			[
+				'nested.first',
+				null,
+				'#FFFFFF',
+				'`#FFFFFF` not returned as one level nested lookup.',
+			],
+			[
+				'nested.second.value',
+				null,
+				'#FFFFFF',
+				'`#FFFFFF` not returned as two levels nested lookup.',
+			],
+			[
+				'nested.third.value',
+				null,
+				'#FFFFFF',
+				'`#FFFFFF` not returned as double nested lookup.',
 			],
 		];
 	}


### PR DESCRIPTION
## Summary
As titled.

## Notes for reviewers
Companion functionality to https://github.com/alleyinteractive/irving/pull/362.

## Changelog entries
* **Added**: Recursive traversalsSupport to the `get_site_theme()` function and tests.

## Ticket(s)
* https://alleyinteractive.atlassian.net/browse/IRV-740