### PR TITLE
Update Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
-sudo: false
-dist: trusty
+# Xenial image has PHP versions 5.6,7.1,7.2 pre-installed
+dist: xenial
 
+# Xenial does not start mysql by default
+services:
+  - mysql
+
+# Declare project language.
+# @link http://about.travis-ci.org/docs/user/languages/php/
 language: php
 
 notifications:
@@ -17,7 +23,7 @@ cache:
   directories:
     - $HOME/.composer/cache
 
-matrix:
+jobs:
   include:
     - php: 7.3
       env: WP_VERSION=latest


### PR DESCRIPTION
The purpose of this PR is to test Travis CI runner, since it had stopped working.

In addition, this updates the config to run on Xenial, which requires declaring mysql as a service. Also uses `jobs` instead of the older alias `matrix`.