### PR TITLE
LEDE-329: Restructure and expand default analytics objects for WP Irving components

### DIFF
--- a/inc/components/components/post-social-sharing/component.json
+++ b/inc/components/components/post-social-sharing/component.json
@@ -42,12 +42,12 @@
     "analytics": {
       "default": {
         "share": {
-          "action": "Share",
-          "category": "Engagement"
-        },
+          "category": "Engagement",
+          "action": "Share"
+        }
+      },
       "description": "Analytics Data",
-      "type": "object"
-      }
+      "type": "array"
     }
   },
   "use_context": {

--- a/inc/components/components/post-social-sharing/component.json
+++ b/inc/components/components/post-social-sharing/component.json
@@ -38,6 +38,14 @@
     "url": {
       "default": "",
       "type": "string"
+    },
+    "gtm_category": {
+      "default": "Engagement",
+      "type": "string"
+    },
+    "gtm_action": {
+      "default": "Share",
+      "type": "string"
     }
   },
   "use_context": {

--- a/inc/components/components/post-social-sharing/component.json
+++ b/inc/components/components/post-social-sharing/component.json
@@ -39,13 +39,15 @@
       "default": "",
       "type": "string"
     },
-    "gtm_category": {
-      "default": "Engagement",
-      "type": "string"
-    },
-    "gtm_action": {
-      "default": "Share",
-      "type": "string"
+    "analytics": {
+      "default": {
+        "share": {
+          "action": "Share",
+          "category": "Engagement"
+        },
+      "description": "Analytics Data",
+      "type": "object"
+      }
     }
   },
   "use_context": {

--- a/inc/components/components/query-pagination/component.json
+++ b/inc/components/components/query-pagination/component.json
@@ -33,6 +33,14 @@
     "wp_query": {
       "hidden": true,
       "type": "object"
+    },
+    "gtm_category": {
+      "default": "Navigation",
+      "type": "string"
+    },
+    "gtm_action": {
+      "default": "Pagination",
+      "type": "string"
     }
   },
   "use_context": {

--- a/inc/components/components/query-pagination/component.json
+++ b/inc/components/components/query-pagination/component.json
@@ -36,7 +36,7 @@
     },
     "analytics": {
       "default": {
-        "pagination": {
+        "click": {
           "action": "Pagination",
           "category": "Navigation"
         }

--- a/inc/components/components/query-pagination/component.json
+++ b/inc/components/components/query-pagination/component.json
@@ -34,13 +34,15 @@
       "hidden": true,
       "type": "object"
     },
-    "gtm_category": {
-      "default": "Navigation",
-      "type": "string"
-    },
-    "gtm_action": {
-      "default": "Pagination",
-      "type": "string"
+    "analytics": {
+      "default": {
+        "pagination": {
+          "action": "Pagination",
+          "category": "Navigation"
+        }
+      },
+      "description": "Analytics Data",
+      "type": "object"
     }
   },
   "use_context": {

--- a/inc/components/components/query-pagination/component.json
+++ b/inc/components/components/query-pagination/component.json
@@ -42,7 +42,7 @@
         }
       },
       "description": "Analytics Data",
-      "type": "object"
+      "type": "array"
     }
   },
   "use_context": {

--- a/inc/components/components/query-seach-form/component.json
+++ b/inc/components/components/query-seach-form/component.json
@@ -19,13 +19,15 @@
       "hidden": true,
       "type": "object"
     },
-    "gtm_action": {
-      "default": "Search",
-      "type": "string"
-    },
-    "gtm_category": {
-      "default": "Navigation",
-      "type": "string"
+    "analytics": {
+      "default": {
+        "search": {
+          "action":  "Search",
+          "category": "Navigation"
+        }
+      },
+      "description": "Analytics Data",
+      "type": "object"
     }
   },
   "use_context": {

--- a/inc/components/components/query-seach-form/component.json
+++ b/inc/components/components/query-seach-form/component.json
@@ -18,6 +18,14 @@
     "wp_query": {
       "hidden": true,
       "type": "object"
+    },
+    "gtm_action": {
+      "default": "Search",
+      "type": "string"
+    },
+    "gtm_category": {
+      "default": "Navigation",
+      "type": "string"
     }
   },
   "use_context": {

--- a/inc/components/components/query-seach-form/component.json
+++ b/inc/components/components/query-seach-form/component.json
@@ -27,7 +27,7 @@
         }
       },
       "description": "Analytics Data",
-      "type": "object"
+      "type": "array"
     }
   },
   "use_context": {

--- a/inc/components/components/site-logo/component.json
+++ b/inc/components/components/site-logo/component.json
@@ -16,17 +16,16 @@
       "default": "",
       "type": "string"
     },
-    "gtm_category": {
-      "default": "Navigation",
-      "type": "string"
-    },
-    "gtm_action": {
-      "default": "Homepage",
-      "type": "string"
-    },
-    "gtm_label": {
-      "default": "Logo",
-      "type": "string"
+    "analytics": {
+      "default": {
+        "click": {
+          "action": "Homepage",
+          "category": "Navigation",
+          "label": "Logo"
+        }
+      },
+      "description": "Analytics Data",
+      "type": "object"
     }
   }
 }

--- a/inc/components/components/site-logo/component.json
+++ b/inc/components/components/site-logo/component.json
@@ -25,7 +25,7 @@
         }
       },
       "description": "Analytics Data",
-      "type": "object"
+      "type": "array"
     }
   }
 }

--- a/inc/components/components/site-logo/component.json
+++ b/inc/components/components/site-logo/component.json
@@ -15,6 +15,18 @@
     "site_name": {
       "default": "",
       "type": "string"
+    },
+    "gtm_category": {
+      "default": "Navigation",
+      "type": "string"
+    },
+    "gtm_action": {
+      "default": "Homepage",
+      "type": "string"
+    },
+    "gtm_label": {
+      "default": "Logo",
+      "type": "string"
     }
   }
 }

--- a/inc/components/components/social-links/component.json
+++ b/inc/components/components/social-links/component.json
@@ -13,6 +13,7 @@
           "category": "Engagement"
         }
       },
+      "description": "Analytics Data",
       "type": "array"
     }
   }

--- a/inc/components/components/social-links/component.json
+++ b/inc/components/components/social-links/component.json
@@ -5,6 +5,15 @@
     "platforms": {
       "type": "array",
       "default": []
+    },
+    "analytics": {
+      "default": {
+        "click": {
+          "action": "Follow",
+          "category": "Engagement"
+        }
+      },
+      "type": "array"
     }
   }
 }

--- a/tests/components/test-components.php
+++ b/tests/components/test-components.php
@@ -858,7 +858,7 @@ class Test_Components extends WP_UnitTestCase {
 				'config' => [
 					'analytics'   => [
 						'share' => [
-							'action'   => 'Follow',
+							'action'   => 'Share',
 							'category' => 'Engagement',
 						],
 					],
@@ -1190,6 +1190,7 @@ class Test_Components extends WP_UnitTestCase {
 						'click' => [
 							'action'   => 'Homepage',
 							'category' => 'Navigation',
+							'label'    => 'Logo',
 						],
 					],
 					'href'         => '/',

--- a/tests/components/test-components.php
+++ b/tests/components/test-components.php
@@ -856,6 +856,12 @@ class Test_Components extends WP_UnitTestCase {
 			[
 				'_alias' => 'irving/social-sharing',
 				'config' => [
+					'analytics'   => [
+						'share' => [
+							'action'   => 'Follow',
+							'category' => 'Engagement',
+						],
+					],
 					'description'  => $this->get_post_excerpt(),
 					'imageUrl'     => $this->get_attachment_url(),
 					'platforms'    => [
@@ -996,6 +1002,12 @@ class Test_Components extends WP_UnitTestCase {
 			[
 				'_alias' => 'irving/pagination',
 				'config' => [
+					'analytics'           => [
+						'click' => [
+							'action'   => 'Pagination',
+							'category' => 'Navigation',
+						],
+					],
 					'currentPage'         => 2,
 					'totalPages'          => 3,
 					'baseUrl'             => "/category/{$category->slug}/",
@@ -1025,6 +1037,12 @@ class Test_Components extends WP_UnitTestCase {
 			[
 				'_alias' => 'irving/search-form',
 				'config' => [
+					'analytics'          => [
+						'search' => [
+							'action'   => 'Search',
+							'category' => 'Navigation',
+						],
+					],
 					'baseUrl'            => '/',
 					'searchTerm'         => 'Irving',
 					'searchTermQueryArg' => 's',
@@ -1168,6 +1186,12 @@ class Test_Components extends WP_UnitTestCase {
 			[
 				'_alias' => 'irving/logo',
 				'config' => [
+					'analytics'    => [
+						'click' => [
+							'action'   => 'Homepage',
+							'category' => 'Navigation',
+						],
+					],
 					'href'         => '/',
 					'logoImageUrl' => $this->get_attachment_url(),
 					'siteName'     => get_bloginfo( 'name' ),

--- a/tests/components/test-components.php
+++ b/tests/components/test-components.php
@@ -856,7 +856,7 @@ class Test_Components extends WP_UnitTestCase {
 			[
 				'_alias' => 'irving/social-sharing',
 				'config' => [
-					'analytics'   => [
+					'analytics'    => [
 						'share' => [
 							'action'   => 'Share',
 							'category' => 'Engagement',


### PR DESCRIPTION
Restructures and expands default analytics objects for WP Irving components.

Pairs with https://github.com/alleyinteractive/irving/pull/372.