### PR TITLE
Ensure `pre_get_posts` fires for empty queries

### DIFF
--- a/inc/endpoints/class-components-endpoint.php
+++ b/inc/endpoints/class-components-endpoint.php
@@ -349,7 +349,7 @@ class Components_Endpoint extends Endpoint {
 		// This ensures we always parse the query so is_home and other flags
 		// get properly set before we handle template.
 		if ( empty( $query ) ) {
-			$wp_query->parse_query();
+			$wp_query->query( $query );
 		}
 
 		/**


### PR DESCRIPTION
See conversation in https://github.com/alleyinteractive/wp-irving/pull/272#discussion_r499976278