### PR TITLE
Use WP arg descriptions for irving/template-part config description

### DIFF
--- a/inc/components/components/template-part/component.json
+++ b/inc/components/components/template-part/component.json
@@ -6,12 +6,12 @@
   "config": {
     "name": {
       "default": "",
-      "description": "The name used to locate the template part.",
+      "description": "The name of the specialized template.",
       "type": "string"
     },
     "slug": {
       "default": "",
-      "description": "The slug used to locate the template part.",
+      "description": "The slug name for the generic template.",
       "type": "string"
     },
     "templates": {


### PR DESCRIPTION
## Summary
As titled.

## Notes for reviewers
Updated as part of the feedback in https://github.com/alleyinteractive/irving/pull/378.

## Changelog entries
* **Changed**: Updated `irving/template-part` config descriptions.

## Ticket(s)
https://alleyinteractive.atlassian.net/browse/IRV-779