### PR TITLE
Modify caching in Coral integration

### DIFF
--- a/inc/integrations/class-coral.php
+++ b/inc/integrations/class-coral.php
@@ -68,6 +68,8 @@ class Coral {
 				}
 			);
 		}
+
+		add_action( "save_post_{$this->post_type}", [ $this, 'delete_cached_values' ], 10, 2 );
 	}
 
 	/**
@@ -523,10 +525,6 @@ class Coral {
 
 		$post = wp_insert_post( $args );
 
-		// Delete stored data for this SSO ID/username.
-		wp_cache_delete( "get_username_{$id}", $this->cache_group );
-		wp_cache_delete( "username_exists_{$username}", $this->cache_group );
-
 		return ( ! is_wp_error( $post ) );
 	}
 
@@ -553,5 +551,20 @@ class Coral {
 		set_transient( $key, $hash, 3600 );
 
 		return $hash;
+	}
+
+	/**
+	 * Delete the cached values when a username post is updated. These
+	 * functions use the post_title column for the user's SSO provider ID, and
+	 * the post_excerpt column for the username.
+	 *
+	 * @param int      $post_ID Post ID.
+	 * @param \WP_Post $post    Post object.
+	 */
+	public function delete_cached_values( $post_id, $post ) {
+		$id       = $post->post_title;
+		$username = $post->post_excerpt;
+		wp_cache_delete( "get_username_{$id}", $this->cache_group );
+		wp_cache_delete( "username_exists_{$username}", $this->cache_group );
 	}
 }

--- a/inc/integrations/class-coral.php
+++ b/inc/integrations/class-coral.php
@@ -558,7 +558,7 @@ class Coral {
 	 * functions use the post_title column for the user's SSO provider ID, and
 	 * the post_excerpt column for the username.
 	 *
-	 * @param int      $post_ID Post ID.
+	 * @param int      $post_id Post ID.
 	 * @param \WP_Post $post    Post object.
 	 */
 	public function delete_cached_values( $post_id, $post ) {

--- a/inc/integrations/class-coral.php
+++ b/inc/integrations/class-coral.php
@@ -38,6 +38,13 @@ class Coral {
 	private $options;
 
 	/**
+	 * Cache group.
+	 *
+	 * @var string
+	 */
+	private $cache_group = 'wp-irving-coral';
+
+	/**
 	 * Setup the singleton. Validate JWT is installed, and setup hooks.
 	 */
 	public function setup() {
@@ -354,7 +361,7 @@ class Coral {
 		global $wpdb;
 
 		$key             = "get_username_{$id}";
-		$stored_username = get_transient( $key );
+		$stored_username = wp_cache_get( $key, $this->cache_group );
 
 		if ( ! empty( $stored_username ) ) {
 			return $stored_username;
@@ -377,11 +384,11 @@ class Coral {
 		);
 
 		/**
-		 * Store the username in a transient.
-		 * The transient is deleted when the username is updated.
+		 * Cache the username.
+		 * The cached value is deleted when the username is updated.
 		 */
 		if ( ! empty( $username ) ) {
-			set_transient( $key, $username );
+			wp_cache_set( $key, $username, $this->cache_group );
 		}
 
 		return $username ?? '';
@@ -398,7 +405,7 @@ class Coral {
 		global $wpdb;
 
 		$key            = "get_username_post_id_{$id}";
-		$stored_post_id = get_transient( $key );
+		$stored_post_id = wp_cache_get( $key, $this->cache_group );
 
 		if ( ! empty( $stored_post_id ) ) {
 			return $stored_post_id;
@@ -421,11 +428,11 @@ class Coral {
 		);
 
 		/**
-		 * Store the post ID in a transient.
+		 * Cache the post ID.
 		 * This can be set forever since the SSO ID to post ID relationship will never change.
 		 */
 		if ( ! empty( $post_id ) ) {
-			set_transient( $key, $post_id );
+			wp_cache_set( $key, $post_id, $this->cache_group );
 		}
 
 		return $post_id ?? 0;
@@ -446,7 +453,7 @@ class Coral {
 		}
 
 		$key                    = "username_exists_{$username}";
-		$stored_username_exists = get_transient( $key );
+		$stored_username_exists = wp_cache_get( $key, $this->cache_group );
 
 		if ( false !== $stored_username_exists ) {
 			return wp_validate_boolean( $stored_username_exists );
@@ -469,10 +476,10 @@ class Coral {
 		) ?? 0;
 
 		/**
-		 * Store the ID for the username in a transient.
-		 * The transient is deleted when the username is added/updated.
+		 * Cache the ID for the username.
+		 * The cached value is deleted when the username is added/updated.
 		 */
-		set_transient( $key, $post_id );
+		wp_cache_set( $key, $post_id, $this->cache_group );
 
 		return ( 0 < $post_id );
 	}
@@ -517,8 +524,8 @@ class Coral {
 		$post = wp_insert_post( $args );
 
 		// Delete stored data for this SSO ID/username.
-		delete_transient( "get_username_{$id}" );
-		delete_transient( "username_exists_{$username}" );
+		wp_cache_delete( "get_username_{$id}", $this->cache_group );
+		wp_cache_delete( "username_exists_{$username}", $this->cache_group );
 
 		return ( ! is_wp_error( $post ) );
 	}

--- a/inc/integrations/class-coral.php
+++ b/inc/integrations/class-coral.php
@@ -349,7 +349,7 @@ class Coral {
 	 * @param string $id The SSO ID of the user.
 	 * @return string The username, or a blank string if none is set.
 	 */
-	private function get_username( $id ) : string {
+	private function get_username( $id ): string {
 		global $wpdb;
 
 		$key             = "get_username_{$id}";
@@ -360,14 +360,14 @@ class Coral {
 		}
 
 		$username = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
-			$wpdb->prepare( 
-				"SELECT post_excerpt 
-					FROM {$wpdb->posts} 
-				WHERE 
+			$wpdb->prepare(
+				"SELECT post_excerpt
+					FROM {$wpdb->posts}
+				WHERE
 					post_title=%s AND
 					post_type=%s AND
 					post_status='publish'
-				LIMIT 1 ",
+				LIMIT 1",
 				[
 					$id,
 					$this->post_type,
@@ -391,7 +391,7 @@ class Coral {
 	 * @param string $id The SSO ID of the user.
 	 * @return int The post ID, or 0 if none is found.
 	 */
-	private function get_username_post_id( $id ) : int {
+	private function get_username_post_id( $id ): int {
 		global $wpdb;
 
 		$key            = "get_username_post_id_{$id}";
@@ -402,14 +402,14 @@ class Coral {
 		}
 
 		$post_id = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
-			$wpdb->prepare( 
-				"SELECT ID 
-					FROM {$wpdb->posts} 
-				WHERE 
+			$wpdb->prepare(
+				"SELECT ID
+					FROM {$wpdb->posts}
+				WHERE
 					post_title=%s AND
 					post_type=%s AND
 					post_status='publish'
-				LIMIT 1 ",
+				LIMIT 1",
 				[
 					$id,
 					$this->post_type,
@@ -433,7 +433,7 @@ class Coral {
 	 * @param string $username The username to check.
 	 * @return bool Whether the name is already in use (true) or not (false).
 	 */
-	private function username_exists( $username ) : int {
+	private function username_exists( $username ): int {
 		global $wpdb;
 
 		if ( ! $username || '' === $username ) {
@@ -448,14 +448,14 @@ class Coral {
 		}
 
 		$post_id = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
-			$wpdb->prepare( 
-				"SELECT ID 
-					FROM {$wpdb->posts} 
-				WHERE 
+			$wpdb->prepare(
+				"SELECT ID
+					FROM {$wpdb->posts}
+				WHERE
 					post_excerpt=%s AND
 					post_type=%s AND
 					post_status='publish'
-				LIMIT 1 ",
+				LIMIT 1",
 				[
 					$username,
 					$this->post_type,
@@ -479,11 +479,11 @@ class Coral {
 	 * @param string $hash     The security hash verifying the request.
 	 * @return bool Whether the create/update operation succeeded.
 	 */
-	private function set_username( $id, $username, $hash ) : bool {
+	private function set_username( $id, $username, $hash ): bool {
 		$key         = 'username_set_hash_' . md5( $id );
 		$stored_hash = get_transient( $key );
 
-		// Stop if the hash doesn't exist, wasn't passed, or doesn't match the one on file. 
+		// Stop if the hash doesn't exist, wasn't passed, or doesn't match the one on file.
 		if ( ! $stored_hash || ! $hash || $hash !== $stored_hash ) {
 			return false;
 		}
@@ -523,7 +523,7 @@ class Coral {
 	 * @param string $email The email for which the hash is valid.
 	 * @return string The hash.
 	 */
-	private function create_username_set_hash( $id, $email ) : string {
+	private function create_username_set_hash( $id, $email ): string {
 		$message = implode(
 			':',
 			[

--- a/inc/integrations/class-coral.php
+++ b/inc/integrations/class-coral.php
@@ -61,6 +61,9 @@ class Coral {
 				}
 			);
 		}
+
+		// Exclude validate_sso_user endpoint from caching on VIP Go.
+		add_filter( 'wpcom_vip_rest_read_response_ttl', [ $this, 'validate_sso_user_endpoint_ttl' ], 10, 4 );
 	}
 
 	/**
@@ -539,5 +542,21 @@ class Coral {
 		set_transient( $key, $hash, 3600 );
 
 		return $hash;
+	}
+
+	/**
+	 * Remove caching on the validate_sso_user endpoint for VIP Go.
+	 *
+	 * @param int               $ttl         The TTL value to use.
+	 * @param \WP_REST_Response $response    The outbound REST API response object.
+	 * @param \WP_REST_Server   $rest_server The REST API server object.
+	 * @param \WP_REST_Request  $request     The incoming REST API request object.
+	 * @return int
+	 */
+	function validate_sso_user_endpoint_ttl( $ttl, $response, $rest_server, $request ) {
+		if ( '/irving/v1/data/validate_sso_user' === $request->get_route() ) {
+			return 0;
+		}
+		return $ttl;
 	}
 }

--- a/inc/integrations/class-coral.php
+++ b/inc/integrations/class-coral.php
@@ -61,9 +61,6 @@ class Coral {
 				}
 			);
 		}
-
-		// Exclude validate_sso_user endpoint from caching on VIP Go.
-		add_filter( 'wpcom_vip_rest_read_response_ttl', [ $this, 'validate_sso_user_endpoint_ttl' ], 10, 4 );
 	}
 
 	/**
@@ -154,7 +151,6 @@ class Coral {
 		<?php
 	}
 
-
 	/**
 	 * Get the endpoint settings.
 	 *
@@ -186,6 +182,8 @@ class Coral {
 	public function process_validate_endpoint_request( \WP_REST_Request $request ) {
 		// Allow access from the frontend.
 		header( 'Access-Control-Allow-Origin: ' . home_url() );
+		// Do not cache the endpoint.
+		header( 'Cache-Control: no-cache, must-revalidate, max-age=0' );
 
 		$user_obj = [
 			'id'    => sanitize_text_field( $request->get_param( 'id' ) ),
@@ -542,21 +540,5 @@ class Coral {
 		set_transient( $key, $hash, 3600 );
 
 		return $hash;
-	}
-
-	/**
-	 * Remove caching on the validate_sso_user endpoint for VIP Go.
-	 *
-	 * @param int               $ttl         The TTL value to use.
-	 * @param \WP_REST_Response $response    The outbound REST API response object.
-	 * @param \WP_REST_Server   $rest_server The REST API server object.
-	 * @param \WP_REST_Request  $request     The incoming REST API request object.
-	 * @return int
-	 */
-	function validate_sso_user_endpoint_ttl( $ttl, $response, $rest_server, $request ) {
-		if ( '/irving/v1/data/validate_sso_user' === $request->get_route() ) {
-			return 0;
-		}
-		return $ttl;
 	}
 }

--- a/inc/integrations/class-coral.php
+++ b/inc/integrations/class-coral.php
@@ -376,8 +376,10 @@ class Coral {
 			)
 		);
 
-		// Store the username in a transient.
-		// The transient is deleted when the username is updated.
+		/**
+		 * Store the username in a transient.
+		 * The transient is deleted when the username is updated.
+		 */
 		if ( ! empty( $username ) ) {
 			set_transient( $key, $username );
 		}
@@ -418,8 +420,10 @@ class Coral {
 			)
 		);
 
-		// Store the post ID in a transient.
-		// This can be set forever since the SSO ID to post ID relationship will never change.
+		/**
+		 * Store the post ID in a transient.
+		 * This can be set forever since the SSO ID to post ID relationship will never change.
+		 */
 		if ( ! empty( $post_id ) ) {
 			set_transient( $key, $post_id );
 		}
@@ -464,8 +468,10 @@ class Coral {
 			)
 		) ?? 0;
 
-		// Store the ID for the username in a transient.
-		// The transient is deleted when the username is added/updated.
+		/**
+		 * Store the ID for the username in a transient.
+		 * The transient is deleted when the username is added/updated.
+		 */
 		set_transient( $key, $post_id );
 
 		return ( 0 < $post_id );

--- a/inc/integrations/class-pantheon.php
+++ b/inc/integrations/class-pantheon.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * WP Irving integration for VIP Go.
+ * WP Irving integration for Pantheon.
  *
  * @package WP_Irving;
  */


### PR DESCRIPTION
## Summary
This PR:
* Bypasses caching on the `/irving/v1/data/validate_sso_user` endpoint. (This helps resolve a bug where users were encountering a second Set Username modal after setting their Coral username for the first time, as the endpoint was returning stale data about the user).
* Adds caching on database queries in the Coral integration class
* Modifies minor code formatting

## Ticket(s)
https://alleyinteractive.atlassian.net/browse/IRV-824