### PR TITLE
IRV-680 replace `master` with `main`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ notifications:
 
 branches:
   only:
-    - master
+    - main
     - production
 
 cache:

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -2,13 +2,13 @@
 
 The following steps should be followed to publish a release of the WP Irving plugin.
 
-1. If this is a major (X.0.0) or minor release (X.Y.0), Create release branch off of the `master` branch: `git checkout -b release/{X.Y}`. If this is a point release (X.Y.Z), check out the relevant release branch `git checkout release/{X.Y}` that already exists.
+1. If this is a major (X.0.0) or minor release (X.Y.0), Create release branch off of the `main` branch: `git checkout -b release/{X.Y}`. If this is a point release (X.Y.Z), check out the relevant release branch `git checkout release/{X.Y}` that already exists.
 2. Update version numbers:
     * Plugin header
     * `WP_IRVING_VERSION` constant
     * composer.json
 3. Update changelog in readme.txt and run `npm run readme` to convert the txt file to a markdown file.
-4. Open a PR from the release branch back to `master`.
+4. Open a PR from the release branch back to `main`.
 5. Create a release candidate:
     * Draft a release from [the GitHub new release page](https://github.com/alleyinteractive/wp-irving/releases/new).
     * Tag the version (e.g., 1.1.0-RC1) and set the target to the release branch.
@@ -22,6 +22,6 @@ The following steps should be followed to publish a release of the WP Irving plu
     * Name the release title using the release version, e.g. 1.1.0
     * Copy the changelog from the RC version and add any other relevant info you want into the release notes
     * Publish the release
-7. Merge the release branch back to `master`
+7. Merge the release branch back to `main`
 8. Publish a release announcement on the Irving Basecamp
 


### PR DESCRIPTION
Summary: 
This PR will replace relevant mentions of `master` with `main`. 

Notes for reviewer:
There are 3 mentions of `master` that are not changed in this PR, because I don't believe they refer to this repo's master branch. Please note if this is incorrect. They are:
- composer.json line 11
`  "require-dev": {`
`    "alleyinteractive/alley-coding-standards": "dev-master"`
` },`
- install-wp-tests.sh line 92
`	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
`
- class-components-endpoint.php line 255
`		// @see https://github.com/WordPress/WordPress/blob/master/wp-includes/class-wp.php#L216-L243
`