### PR TITLE
HOTFIX: WPCOM Legacy Redirector

### DIFF
--- a/inc/endpoints/class-components-endpoint.php
+++ b/inc/endpoints/class-components-endpoint.php
@@ -137,7 +137,8 @@ class Components_Endpoint extends Endpoint {
 		 * Offer redirector integrations an opportunity to act here to bypass
 		 * rendering an irrelevant page.
 		 *
-		 * @param array $redirect An assocative array with redirectTo (url) and redirectStatus (HTTP code, e.g. 301 or 302).
+		 * @param array $redirect An associative array with redirectTo (url) and redirectStatus (HTTP code, e.g. 301 or 302).
+		 * @param array $params   WP REST Request parameters.
 		 */
 		$redirect = apply_filters(
 			'wp_irving_components_redirect',

--- a/inc/integrations/class-wpcom-legacy-redirector.php
+++ b/inc/integrations/class-wpcom-legacy-redirector.php
@@ -37,8 +37,8 @@ class WPCOM_Legacy_Redirector {
 	/**
 	 * Find any matching redirect for requested path and include in response data.
 	 *
-	 * @param array $data   WP Irving redirect data.
-	 * @param array $params REST request.
+	 * @param array $data   An associative array with redirectTo (url) and redirectStatus (HTTP code, e.g. 301 or 302).
+	 * @param array $params WP REST Request parameters.
 	 * @return array Filtered WP Irving redirect data.
 	 */
 	public function handle_redirect( array $data, array $params ) : array {

--- a/inc/integrations/class-wpcom-legacy-redirector.php
+++ b/inc/integrations/class-wpcom-legacy-redirector.php
@@ -37,11 +37,11 @@ class WPCOM_Legacy_Redirector {
 	/**
 	 * Find any matching redirect for requested path and include in response data.
 	 *
-	 * @param array            $data    WP Irving response data.
-	 * @param \WP_REST_Request $request REST request.
+	 * @param array $data   WP Irving redirect data.
+	 * @param array $params REST request.
+	 * @return array Filtered WP Irving redirect data.
 	 */
-	public function handle_redirect( $data, $request ) : array {
-		$params = $request->get_params();
+	public function handle_redirect( array $data, array $params ) : array {
 
 		if ( empty( $params['path'] ) ) {
 			return $data;


### PR DESCRIPTION
`wp_irving_components_redirect` filter is passed two arrays, second one being the `params`. No need to access through `get_params()`.