### PR TITLE
Add CODEOWNERS file to the repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# This file assigns responsibility for reviewing specific files
+# in this repo to specific people or teams.
+# See: https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+# Assign default ownership to the @alleyinteractive/irving team.
+*	@alleyinteractive/irving


### PR DESCRIPTION
This adds a `.github/CODEOWNERS` file to the project, which will automatically
request PR reviews to anyone in the @alleyinteractive/irving team, and can
be used to ensure that nothing gets committed to protected branches without
a review from a codeowner.