### PR TITLE
Add multi key context support

### DIFF
--- a/inc/components/class-component.php
+++ b/inc/components/class-component.php
@@ -817,7 +817,18 @@ class Component implements JsonSerializable {
 
 			// Apply context values to config keys if set.
 			if ( null !== $store->get( $key ) ) {
-				$this->set_config_value( $config, $store->get( $key ) );
+				if ( is_array( $config ) ) {
+					// Handle destructuring object properties
+					// to specific config values first.
+					$obj = $store->get( $key );
+
+					foreach ( $config as $prop => $value ) {
+						$this->set_config_value( $value, $obj->$prop );
+					}
+				} else {
+					// Set simple string-based values.
+					$this->set_config_value( $config, $store->get( $key ) );
+				}
 			}
 		}
 

--- a/tests/components/test-class-component.php
+++ b/tests/components/test-class-component.php
@@ -334,6 +334,7 @@ class Test_Class_Component extends WP_UnitTestCase {
 			[
 				'test/foo' => 'bar',
 				'test/baz' => null,
+				'test/obj' => null,
 			],
 			$component->get_context(),
 			'Calculated context values not set.'
@@ -346,13 +347,12 @@ class Test_Class_Component extends WP_UnitTestCase {
 	 * @dataProvider provide_context_config_data
 	 * @group context
 	 *
+	 * @param array $context  Test context values.
 	 * @param array $config   Test config values.
 	 * @param array $expected Expected value.
 	 */
-	public function test_context_values_set( $config, $expected ) {
-		get_context_store()->set(
-			[ 'test/foo' => 'bar' ]
-		);
+	public function test_context_values_set( array $context, array $config, array $expected ) {
+		get_context_store()->set( $context );
 
 		// 'test/use-context' is a registered type.
 		$component = new Component(
@@ -363,7 +363,7 @@ class Test_Class_Component extends WP_UnitTestCase {
 		// Clean up.
 		get_context_store()->reset();
 
-		$this->assertSame(
+		$this->assertEquals(
 			$expected,
 			$component->get_config()
 		);
@@ -375,21 +375,42 @@ class Test_Class_Component extends WP_UnitTestCase {
 	 * @return array[]
 	 */
 	public function provide_context_config_data() {
+		// Set up a generic object for setting context.
+		$obj = new stdClass();
+
+		$obj->test_prop = 'value';
+
 		return [
+			// String based context.
 			[
+				[ 'test/foo' => 'bar' ],
 				[],
 				[
 					'foo' => 'bar',
 					'baz' => 'default',
+					'obj' => 'default',
 				],
 			],
+			// Object based context.
 			[
+				[ 'test/obj' => $obj ],
+				[],
+				[
+					'foo' => 'default',
+					'baz' => 'default',
+					'obj' => 'value',
+				],
+			],
+			// Set context, but override via constructor.
+			[
+				[ 'test/foo' => 'bar' ],
 				[
 					'foo' => 'overridden',
 				],
 				[
 					'foo' => 'overridden',
 					'baz' => 'default',
+					'obj' => 'default',
 				],
 			],
 		];

--- a/tests/components/test-components/use-context.json
+++ b/tests/components/test-components/use-context.json
@@ -8,10 +8,17 @@
     "baz": {
       "default": "default",
       "type": "string"
+    },
+    "obj": {
+      "default": "default",
+      "type": "string"
     }
   },
   "use_context": {
     "test/foo": "foo",
-    "test/baz": "baz"
+    "test/baz": "baz",
+    "test/obj": {
+      "test_prop": "obj"
+    }
   }
 }


### PR DESCRIPTION
This allows a component to map properties of an object to specific config
values using the following notation:

```json
{
  "name": "example/component",
  "use_context": {
    "example/object": {
      "prop_foo": "config_key_bar"
    }
  }
}
```

It the above example, if `$object` is set as the value of the example/object
context. The example component will map the the value of `$object->prop_foo`
to it's own `config_key_bar` config value during hydration.