### PR TITLE
0.6.0 Release Prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,49 +19,64 @@ While WP Irving contains a few basic plugin integrations (and we hope to support
 
 ## Changelog ##
 
+### 0.6.0 ###
+
+* Add irving/template-part component (#281)
+* Fix redirects and improve performance (#283)
+* Update AMP integration (#284)
+* Update Alley Coding Standards (#285)
+* Update Localize sitetheme when enqueueing editor styles (#286)
+* Update caching in the Coral integration (#287)
+* Change default branch from 'master' to 'main' (#288)
+* Improve handling of empty paths by the component API (#289)
+* Fix WPCom Legacy Redirector integration (#290)
+* Add default analytics data to components (#276)
+* Add multi-key context support (#292)
+* Update Travis configuration (#293)
+
 ### 0.5.1 ###
 
 * Update: Change coding standard to Alley Interactive
 
 ### 0.5.0 ###
 
-* Limit Pico paywall to posts by default #279
-* Changes related to new @irvingjs/wordpress package #278
-* Ensure `pre_get_posts` fires for empty queries #277
-* Add support for body classes #273
-* Fix setting global WordPress properties #267
-* Update Travis config #275
-* Add support for nested site theme values #270
-* GTM: Escape the site path in the data layer #269
-* Add HTML encoding to menu name #268
-* Refactor site-info component #266
-* Add options for camel casing keys #265
-* Pico: Add support for using the staging widget URL #263
-* Add `class_name` and style as default configs #262
-* Add checkbox for Pico staging URLs #261
+* Limit Pico paywall to posts by default (#279)
+* Changes related to new @irvingjs/wordpress package (#278)
+* Ensure `pre_get_posts` fires for empty queries (#277)
+* Add support for body classes (#273)
+* Fix setting global WordPress properties (#267)
+* Update Travis config (#275)
+* Add support for nested site theme values (#270)
+* GTM: Escape the site path in the data layer (#269)
+* Add HTML encoding to menu name (#268)
+* Refactor site-info component (#266)
+* Add options for camel casing keys (#265)
+* Pico: Add support for using the staging widget URL (#263)
+* Add `class_name` and style as default configs (#262)
+* Add checkbox for Pico staging URLs (#261)
 
 ### 0.4.0 ###
 
-* Update social share component. #259
-* Add fragment property to post permalink component config. #258
-* Add support for a fallback image in the customizer. #257
-* Add initial data layer to GTM integrations. #255
-* Add banned usernames field for Coral. #256
-* Add allowed tiers input for Pico/Coral SSO to Irving Integrations settings page. #254
-* Allow user to set custom username through Pico/Coral integration. #241
-* Add image performance enhancements in irving/post-featured-image. #251
-* Add `post_ids_to_skip` config to the `irving/post-list` component. #250
-* Implement local WP username storage for Coral users. #249
-* Support item overrides in irving/post-list components. #247
-* Hydrate WordPress data for images. #244
-* Improvements to <head> management, and block library support. #246
-* Ensure post previews do not use the homepage template. #248
-* Enqueue block library styles. #243
-* Add share links config to social sharing component. #242
-* Remove unnecessary second param for VIP cache purge filter. #240
-* Add support to the pagination component for post type archives. #239
-* Define component for Coral to be included in template JSON. #222
-* Allow use_context in templates. #223
+* Update social share component. (#259)
+* Add fragment property to post permalink component config. (#258)
+* Add support for a fallback image in the customizer. (#257)
+* Add initial data layer to GTM integrations. (#255)
+* Add banned usernames field for Coral. (#256)
+* Add allowed tiers input for Pico/Coral SSO to Irving Integrations settings page. (#254)
+* Allow user to set custom username through Pico/Coral integration. (#241)
+* Add image performance enhancements in irving/post-featured-image. (#251)
+* Add `post_ids_to_skip` config to the `irving/post-list` component. (#250)
+* Implement local WP username storage for Coral users. (#249)
+* Support item overrides in irving/post-list components. (#247)
+* Hydrate WordPress data for images. (#244)
+* Improvements to <head> management, and block library support. (#246)
+* Ensure post previews do not use the homepage template. (#248)
+* Enqueue block library styles. (#243)
+* Add share links config to social sharing component. (#242)
+* Remove unnecessary second param for VIP cache purge filter. (#240)
+* Add support to the pagination component for post type archives. (#239)
+* Define component for Coral to be included in template JSON. (#222)
+* Allow use_context in templates. (#223)
 
 ### 0.3.0 ###
 * Fix: Cache clearing redirect

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
   "name": "alleyinteractive/wp-irving",
-  "version": "0.6.0-alpha",
   "authors": [
     {
       "name": "Alley Interactive",

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -3,10 +3,7 @@
 The following steps should be followed to publish a release of the WP Irving plugin.
 
 1. If this is a major (X.0.0) or minor release (X.Y.0), Create release branch off of the `main` branch: `git checkout -b release/{X.Y}`. If this is a point release (X.Y.Z), check out the relevant release branch `git checkout release/{X.Y}` that already exists.
-2. Update version numbers:
-    * Plugin header
-    * `WP_IRVING_VERSION` constant
-    * composer.json
+2. Update version number in the plugin header
 3. Update changelog in readme.txt and run `npm run readme` to convert the txt file to a markdown file.
 4. Open a PR from the release branch back to `main`.
 5. Create a release candidate:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,7 @@
 {
   "name": "wp-irving",
-  "version": "0.4.0",
-  "lockfileVersion": 1,
   "requires": true,
+  "lockfileVersion": 1,
   "dependencies": {
     "minimist": {
       "version": "1.2.5",

--- a/readme.txt
+++ b/readme.txt
@@ -19,49 +19,64 @@ While WP Irving contains a few basic plugin integrations (and we hope to support
 
 == Changelog ==
 
+= 0.6.0 =
+
+* Add irving/template-part component (#281)
+* Fix redirects and improve performance (#283)
+* Update AMP integration (#284)
+* Update Alley Coding Standards (#285)
+* Update Localize sitetheme when enqueueing editor styles (#286)
+* Update caching in the Coral integration (#287)
+* Change default branch from 'master' to 'main' (#288)
+* Improve handling of empty paths by the component API (#289)
+* Fix WPCom Legacy Redirector integration (#290)
+* Add default analytics data to components (#276)
+* Add multi-key context support (#292)
+* Update Travis configuration (#293)
+
 = 0.5.1 =
 
 * Update: Change coding standard to Alley Interactive
 
 = 0.5.0 =
 
-* Limit Pico paywall to posts by default #279
-* Changes related to new @irvingjs/wordpress package #278
-* Ensure `pre_get_posts` fires for empty queries #277
-* Add support for body classes #273
-* Fix setting global WordPress properties #267
-* Update Travis config #275
-* Add support for nested site theme values #270
-* GTM: Escape the site path in the data layer #269
-* Add HTML encoding to menu name #268
-* Refactor site-info component #266
-* Add options for camel casing keys #265
-* Pico: Add support for using the staging widget URL #263
-* Add `class_name` and style as default configs #262
-* Add checkbox for Pico staging URLs #261
+* Limit Pico paywall to posts by default (#279)
+* Changes related to new @irvingjs/wordpress package (#278)
+* Ensure `pre_get_posts` fires for empty queries (#277)
+* Add support for body classes (#273)
+* Fix setting global WordPress properties (#267)
+* Update Travis config (#275)
+* Add support for nested site theme values (#270)
+* GTM: Escape the site path in the data layer (#269)
+* Add HTML encoding to menu name (#268)
+* Refactor site-info component (#266)
+* Add options for camel casing keys (#265)
+* Pico: Add support for using the staging widget URL (#263)
+* Add `class_name` and style as default configs (#262)
+* Add checkbox for Pico staging URLs (#261)
 
 = 0.4.0 =
 
-* Update social share component. #259
-* Add fragment property to post permalink component config. #258
-* Add support for a fallback image in the customizer. #257
-* Add initial data layer to GTM integrations. #255
-* Add banned usernames field for Coral. #256
-* Add allowed tiers input for Pico/Coral SSO to Irving Integrations settings page. #254
-* Allow user to set custom username through Pico/Coral integration. #241
-* Add image performance enhancements in irving/post-featured-image. #251
-* Add `post_ids_to_skip` config to the `irving/post-list` component. #250
-* Implement local WP username storage for Coral users. #249
-* Support item overrides in irving/post-list components. #247
-* Hydrate WordPress data for images. #244
-* Improvements to <head> management, and block library support. #246
-* Ensure post previews do not use the homepage template. #248
-* Enqueue block library styles. #243
-* Add share links config to social sharing component. #242
-* Remove unnecessary second param for VIP cache purge filter. #240
-* Add support to the pagination component for post type archives. #239
-* Define component for Coral to be included in template JSON. #222
-* Allow use_context in templates. #223
+* Update social share component. (#259)
+* Add fragment property to post permalink component config. (#258)
+* Add support for a fallback image in the customizer. (#257)
+* Add initial data layer to GTM integrations. (#255)
+* Add banned usernames field for Coral. (#256)
+* Add allowed tiers input for Pico/Coral SSO to Irving Integrations settings page. (#254)
+* Allow user to set custom username through Pico/Coral integration. (#241)
+* Add image performance enhancements in irving/post-featured-image. (#251)
+* Add `post_ids_to_skip` config to the `irving/post-list` component. (#250)
+* Implement local WP username storage for Coral users. (#249)
+* Support item overrides in irving/post-list components. (#247)
+* Hydrate WordPress data for images. (#244)
+* Improvements to <head> management, and block library support. (#246)
+* Ensure post previews do not use the homepage template. (#248)
+* Enqueue block library styles. (#243)
+* Add share links config to social sharing component. (#242)
+* Remove unnecessary second param for VIP cache purge filter. (#240)
+* Add support to the pagination component for post type archives. (#239)
+* Define component for Coral to be included in template JSON. (#222)
+* Allow use_context in templates. (#223)
 
 = 0.3.0 =
 * Fix: Cache clearing redirect

--- a/wp-irving.php
+++ b/wp-irving.php
@@ -6,7 +6,7 @@
  * Author URI:      https://alley.co
  * Text Domain:     wp-irving
  * Domain Path:     /languages
- * Version:         0.6.0-alpha
+ * Version:         0.6.0
  *
  * @package         WP_Irving
  */
@@ -15,7 +15,6 @@ namespace WP_Irving;
 
 define( 'WP_IRVING_PATH', dirname( __FILE__ ) );
 define( 'WP_IRVING_URL', plugin_dir_url( __FILE__ ) );
-define( 'WP_IRVING_VERSION', '0.6.0-alpha' );
 
 // Flush rewrite rules when the plugin is activated or deactivated.
 register_activation_hook( __FILE__, 'flush_rewrite_rules' );


### PR DESCRIPTION
- Bump version number
- Add Changelogs

Note: This removes the version number constant from the plugin
and the version number in composer.json, since both are unnecessary.
The release process docs are updated to reflect this change.