### PR TITLE
Add filter to disable camel casing of config keys

### DIFF
--- a/inc/components/class-component.php
+++ b/inc/components/class-component.php
@@ -1034,7 +1034,7 @@ class Component implements JsonSerializable {
 		 * Filter whether camel casing is enabled.
 		 *
 		 * @since 0.7.0
-         *
+		 *
 		 * @param bool $do_camel_case Whether camel casing is enabled. Default true.
 		 */
 		$do_camel_case = apply_filters( 'wp_irving_camel_case', true );
@@ -1086,9 +1086,10 @@ class Component implements JsonSerializable {
 				'theme_options',
 			];
 
-			foreach( $config as $key => $value ) {
+			foreach ( $config as $key => $value ) {
 				if ( in_array( $key, $force_camel_keys ) ) {
 					$new_key = $this->camel_case( $key );
+
 					$config[ $new_key ] = $value;
 					unset( $config[ $key ] );
 				}

--- a/tests/components/test-class-component.php
+++ b/tests/components/test-class-component.php
@@ -740,6 +740,61 @@ class Test_Class_Component extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test camel casing disabled.
+	 *
+	 * @group camel-case
+	 */
+	public function test_disabling_camel_casing() {
+		// Disable camel casing during serialization.
+		add_filter( 'wp_irving_camel_case', '__return_false' );
+
+		$component = new Component(
+			'example/no-camels',
+			[
+				'config' => [
+					'under_score' => 'under_score',
+					'camelCase'   => 'camelCase',
+					'cabob-case'  => 'cabob-case',
+					'nested_case' => [
+						'under_score' => 'under_score',
+						'camelCase'   => 'camelCase',
+						'cabob-case'  => 'cabob-case',
+					],
+				],
+				'theme' => 'no_camels',
+			]
+		);
+
+		$expected = [
+			'name'     => 'example/no-camels',
+			'_alias'   => '',
+			'config'   => (object) [
+				'className'    => '',
+				'style'        => [],
+				'themeName'    => 'no_camels',
+				'themeOptions' => [
+					'default',
+				],
+				'under_score' => 'under_score',
+				'camelCase'   => 'camelCase',
+				'cabob-case'  => 'cabob-case',
+				'nested_case' => [
+					'under_score' => 'under_score',
+					'camelCase'   => 'camelCase',
+					'cabob-case'  => 'cabob-case',
+				],
+			],
+			'children' => [],
+		];
+
+		$this->assertEquals(
+			$expected,
+			$component->jsonSerialize(),
+		);
+
+	}
+
+	/**
 	 * Modify the config value of a component (as an array) using a filter.
 	 *
 	 * @param array $component Component (as an array).

--- a/tests/components/test-class-component.php
+++ b/tests/components/test-class-component.php
@@ -761,7 +761,7 @@ class Test_Class_Component extends WP_UnitTestCase {
 						'cabob-case'  => 'cabob-case',
 					],
 				],
-				'theme' => 'no_camels',
+				'theme'  => 'no_camels',
 			]
 		);
 
@@ -775,10 +775,10 @@ class Test_Class_Component extends WP_UnitTestCase {
 				'themeOptions' => [
 					'default',
 				],
-				'under_score' => 'under_score',
-				'camelCase'   => 'camelCase',
-				'cabob-case'  => 'cabob-case',
-				'nested_case' => [
+				'under_score'  => 'under_score',
+				'camelCase'    => 'camelCase',
+				'cabob-case'   => 'cabob-case',
+				'nested_case'  => [
 					'under_score' => 'under_score',
 					'camelCase'   => 'camelCase',
 					'cabob-case'  => 'cabob-case',

--- a/tests/components/test-class-component.php
+++ b/tests/components/test-class-component.php
@@ -741,8 +741,6 @@ class Test_Class_Component extends WP_UnitTestCase {
 
 	/**
 	 * Test camel casing disabled.
-	 *
-	 * @group camel-case
 	 */
 	public function test_disabling_camel_casing() {
 		// Disable camel casing during serialization.


### PR DESCRIPTION
This adds a new filter, named 'wp_irving_camel_case' which defaults to
`true` and allows camel casing to be disabled during hydration.

When disabled, the only config keys that will be camel cased are
`class_name`, `theme_name`, and `theme_option`.

Example:

```php
add_filter( 'wp_irving_camel_case', '__return_false' );
```