### PR TITLE
Fix ability to override theme in a config callback

### DIFF
--- a/inc/components/class-component.php
+++ b/inc/components/class-component.php
@@ -199,7 +199,7 @@ class Component implements JsonSerializable {
 			->apply_context()
 			->set_config( $args['config'] )
 			->hydrate_config()
-			->set_theme( 'irving/site-theme' !== $this->get_name() ? $args['config']['theme'] : $args['theme'] )
+			->set_theme( 'irving/site-theme' !== $this->get_name() ? $this->get_config( 'theme' ) : $args['theme'] )
 			->set_children( $args['children'] );
 
 		return $this;

--- a/tests/components/test-class-component.php
+++ b/tests/components/test-class-component.php
@@ -183,10 +183,11 @@ class Test_Class_Component extends WP_UnitTestCase {
 			[
 				[
 					'test-default' => 'overridden',
+					'theme'        => 'overridden',
 				],
 				[
 					'test-default' => 'overridden',
-					'theme'        => 'default',
+					'theme'        => 'overridden',
 				],
 				'Default config values not overridden.',
 			],
@@ -473,6 +474,36 @@ class Test_Class_Component extends WP_UnitTestCase {
 			],
 			$component->get_config()
 		);
+	}
+
+	/**
+	 * Test overriding `theme` in a config callback.
+	 */
+	public function test_config_callback_for_theme() {
+		$name = 'example/component';
+
+		/*
+		 * Register component with callback.
+		 *
+		 * We're using a callback that uses the config in order
+		 * to ensure that the callback is passed an array.
+		 */
+		get_registry()->register_component(
+			$name,
+			[
+				'config_callback' => function ( array $config ) {
+					$config['theme'] = 'fred';
+					return $config;
+				},
+			]
+		);
+
+		$component = new Component( $name );
+
+		// Clean up.
+		get_registry()->unregister_component( $name );
+
+		$this->assertEquals( 'fred', $component->get_theme() );
 	}
 
 	/**


### PR DESCRIPTION
Refs: [IRV-909](https://alleyinteractive.atlassian.net/browse/IRV-909)

This fixes a bug where
```php
Components\register_component_from_config(
	__DIR__ . '/component',
	[
		'config_callback' => function( array $config ): array {
			$config['theme'] = 'my_new_theme';
			return $config;
		},
	]
);
```

resulted in
```json
...
"config": {
  "themeName": "default",
},
...
```

Now, it will result in
```json
...
"config": {
  "themeName": "myNewTheme",
},
...
```
as expected
