### PR TITLE
Add script for drafting changelogs

### DIFF
--- a/bin/script-draft-changelog.sh
+++ b/bin/script-draft-changelog.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+getTag(){
+	git describe --tags `git rev-list --tags --max-count=1`
+}
+
+echo "Listing changes since tag: $(getTag)"
+
+# List all merge commits since the last tag.
+git log --reverse --merges --pretty="* %f – %b"  HEAD...$(getTag)

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
   },
   "scripts": {
     "phpcs": "phpcs . -p",
-    "phpcbf": "phpcbf ."
+    "phpcbf": "phpcbf .",
+    "changelog": "./bin/script-draft-changelog.sh"
   }
 }

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -4,7 +4,7 @@ The following steps should be followed to publish a release of the WP Irving plu
 
 1. If this is a major (X.0.0) or minor release (X.Y.0), Create release branch off of the `main` branch: `git checkout -b release/{X.Y}`. If this is a point release (X.Y.Z), check out the relevant release branch `git checkout release/{X.Y}` that already exists.
 2. Update version number in the plugin header
-3. Update changelog in readme.txt and run `npm run readme` to convert the txt file to a markdown file.
+3. Update changelog in readme.txt and run `npm run readme` to convert the txt file to a markdown file. To quickly draft a changelog, you can run `composer changelog` to get a list of merge commits since the last tag.
 4. Open a PR from the release branch back to `main`.
 5. Create a release candidate:
     * Draft a release from [the GitHub new release page](https://github.com/alleyinteractive/wp-irving/releases/new).


### PR DESCRIPTION
- Adds file: bin/script-draft-changelog.sh that formats a list of changes since the last tag
- Adds composer script "changelog" as a shortcut for the above
- Updates the RELEASE.md doc to include a note about this utility