### PR TITLE
Update site-menu component to allow explicitly setting the menu name

### DIFF
--- a/inc/components/components/site-menu/component.json
+++ b/inc/components/components/site-menu/component.json
@@ -21,7 +21,7 @@
     },
     "menu_name": {
       "type": "string",
-      "default": "Default"
+      "default": ""
     }
   }
 }

--- a/inc/components/components/site-menu/component.php
+++ b/inc/components/components/site-menu/component.php
@@ -52,6 +52,11 @@ register_component_from_config(
 
 			$menu_items = wp_get_nav_menu_items( $config['menu_id'] );
 
+			// Validate $menu_items is an array of items.
+			if ( ! is_array( $menu_items ) ) {
+				return $children;
+			}
+
 			/*
 			 * Sort the menu items into two groups: top level items, and a list
 			 * of sub-menu items organized by parent ID. Then we can recursively

--- a/inc/components/components/site-menu/component.php
+++ b/inc/components/components/site-menu/component.php
@@ -20,7 +20,7 @@ register_component_from_config(
 	[
 		'config_callback'   => function ( array $config ): array {
 
-			// Get menu ID for the selected location.
+			// Get menu ID (int) for the selected location.
 			$config['menu_id'] = get_nav_menu_locations()[ $config['location'] ] ?? 0;
 
 			if ( ! $config['menu_id'] ) {
@@ -34,7 +34,10 @@ register_component_from_config(
 				return $config;
 			}
 
-			$config['menu_name'] = html_entity_decode( $menu_object->name ?? $config['menu_name'] );
+			// Use the Menu Object name if not declared explicitly.
+			if ( empty( $config['menu_name'] ) && isset( $menu_object->name ) ) {
+				$config['menu_name'] = html_entity_decode( $menu_object->name );
+			}
 
 			return $config;
 		},
@@ -47,7 +50,7 @@ register_component_from_config(
 				return $children;
 			}
 
-			$menu_items = wp_get_nav_menu_items( $config['menu_name'] );
+			$menu_items = wp_get_nav_menu_items( $config['menu_id'] );
 
 			/*
 			 * Sort the menu items into two groups: top level items, and a list

--- a/tests/components/test-components.php
+++ b/tests/components/test-components.php
@@ -1376,6 +1376,38 @@ class Test_Components extends WP_UnitTestCase {
 
 		$this->assertComponentEquals( $expected, $component );
 
+		// Ensure the menu name defaults to the name set in WP.
+		$this->assertEquals(
+			(
+				new Component(
+					'irving/site-menu',
+					[
+						'config' => [
+							'location' => 'test-location',
+						],
+					]
+				)
+			)->get_config( 'menu_name' ),
+			'test-menu',
+			'The menu name is not defaulting to test-menu.'
+		);
+
+		// Ensure the menu name can be set explicitly.
+		$this->assertEquals(
+			(
+				new Component(
+					'irving/site-menu',
+					[
+						'config' => [
+							'location'  => 'test-location',
+							'menu_name' => 'About Us',
+						],
+					]
+				)
+			)->get_config( 'menu_name' ),
+			'About Us',
+			'The menu name was not explicitly set via config.'
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary
As titled.

## Notes for reviewers
None.

## Changelog entries
* **Changed**: Use menu ID to get the menu items, instead of the menu `WP_Term` name.
* **Fixed**: If `$config['menu_name']` is explicitly set, don't override it.

## Ticket(s)
https://alleyinteractive.atlassian.net/browse/IRV-882