### PR TITLE
Cache full site theme value to improve performance

### DIFF
--- a/inc/templates/site-theme.php
+++ b/inc/templates/site-theme.php
@@ -54,7 +54,7 @@ function get_site_theme( string $selector = '', $default = null ) {
 
 	// Get cached site theme value, if available.
 	$cache_key = 'wp_irving_site_theme';
-	$theme     = get_transient( $cache_key );
+	$theme     = wp_cache_get( $cache_key );
 	if ( false === $theme ) {
 		/**
 		 * Filter to modify the site theme.
@@ -63,7 +63,7 @@ function get_site_theme( string $selector = '', $default = null ) {
 		 */
 		$theme = apply_filters( 'wp_irving_setup_site_theme', get_site_theme_from_json_files() );
 		// Cache the value.
-		set_transient( $cache_key, $theme, 30 );
+		wp_cache_set( $cache_key, $theme, '', 1 * MINUTE_IN_SECONDS );
 	}
 
 	// Get the entire theme.

--- a/inc/templates/site-theme.php
+++ b/inc/templates/site-theme.php
@@ -52,12 +52,19 @@ function setup_site_theme_provider( array $data ): array {
  */
 function get_site_theme( string $selector = '', $default = null ) {
 
-	/**
-	 * Filter to modify the site theme.
-	 *
-	 * @var array
-	 */
-	$theme = apply_filters( 'wp_irving_setup_site_theme', get_site_theme_from_json_files() );
+	// Get cached site theme value, if available.
+	$cache_key = 'wp_irving_site_theme';
+	$theme     = get_transient( $cache_key );
+	if ( false === $theme ) {
+		/**
+		 * Filter to modify the site theme.
+		 *
+		 * @var array
+		 */
+		$theme = apply_filters( 'wp_irving_setup_site_theme', get_site_theme_from_json_files() );
+		// Cache the value.
+		set_transient( $cache_key, $theme, 30 );
+	}
 
 	// Get the entire theme.
 	if ( empty( $selector ) ) {


### PR DESCRIPTION
Generating the full site theme via `get_site_theme_from_json_files()` (which finds files in a directory, loads the contents from JSON, and compiles to an array) each time `get_site_theme()` was called was getting pretty expensive (given that it might get called 1000+ times per page load). Caching the site theme value in a transient for even a very short duration makes local dev in particular much snappier.