### PR TITLE
Update Pico staging URL in our integration

### DIFF
--- a/inc/integrations/class-pico.php
+++ b/inc/integrations/class-pico.php
@@ -72,7 +72,7 @@ class Pico {
 			}
 
 			if ( ! defined( 'PP_WIDGET_ENDPOINT' ) ) {
-				define( 'PP_WIDGET_ENDPOINT', 'https://widget.staging.pico.tools' ); // phpcs:ignore
+				define( 'PP_WIDGET_ENDPOINT', 'https://gadget.staging.pico.tools' ); // phpcs:ignore
 			}
 		}
 	}


### PR DESCRIPTION
The new domain since Pico v1.0.0 is now `https://gadget.staging.pico.tools`.