### PR TITLE
Update New Relic integration to better typecast

### DIFF
--- a/inc/integrations/class-new-relic.php
+++ b/inc/integrations/class-new-relic.php
@@ -60,6 +60,16 @@ class New_Relic {
 				$params = $request->get_params();
 
 				foreach ( $params as $param => $content ) {
+
+					// Ensure $content is always a scalar.
+					if (
+						! is_scalar( $content )
+						|| is_array( $content )
+						|| is_object( $content )
+					) {
+						$content = wp_json_encode( $content );
+					}
+
 					\newrelic_add_custom_parameter( 'wp-api-' . $param, $content );
 				}
 


### PR DESCRIPTION
## Summary
New Relic was reporting issues with non-scalar values.

`newrelic_add_custom_parameter(): newrelic_add_custom_parameter: expects parameter to be scalar, array given`

## Notes for reviewers
None.

## Changelog entries
* **Fixed**: Typecasting for Scalar values.

## Ticket(s)
None.