### PR TITLE
prevent favicon requests from affecting cookies

### DIFF
--- a/inc/integrations/class-application-passwords-auth.php
+++ b/inc/integrations/class-application-passwords-auth.php
@@ -89,6 +89,10 @@ class Application_Passwords_Auth {
 	 * Handle the cookie logic upon init.
 	 */
 	public function handle_cookie() {
+		// Prevent Favicon requests from affecting cookies.
+		if ( isset( $_SERVER['REQUEST_URI'] ) && '/favicon.ico' === $_SERVER['REQUEST_URI'] ) {
+			return;
+		}
 
 		/**
 		 * Determine the cross domain cookie domain.


### PR DESCRIPTION
**_This PR may not address the root cause of the issue._**

I am seeing a situation while using Application Passwords where favicon requests are unsetting domain authorization cookies. The code in this PR prevents favicon requests from unsetting cookie values, but the cause of the issue might be further up in the request lifecycle.

WP-Irving:  v0.9.0
@irvingjs/core: "6.2.0
@irvingjs/integrations: ^6.2.0