### PR TITLE
Refactor Post List to deduplicate posts more performantly

### DIFF
--- a/inc/components/components/post-list/component.php
+++ b/inc/components/components/post-list/component.php
@@ -18,22 +18,17 @@ register_component_from_config(
 	__DIR__ . '/component',
 	[
 		'config_callback'   => function ( array $config ): array {
+
+			// Grab the global in case we need it.
 			global $wp_query;
-			$query = $wp_query;
 
-			$query_args = $config['query_args'] ?? [];
-
-			if ( ! empty( $query_args ) ) {
-
-				if ( wp_validate_boolean( $query_args['exclude'] ?? false ) ) {
-					$query_args['post__not_in'] = post_list_get_and_add_used_post_ids();
-				}
-
-				// Create a new `WP_Query` object for the data provider/consumers.
-				$query = new WP_Query( $query_args );
-			}
-
-			$config['wp_query'] = $query;
+			/**
+			 * Fallback to the global WP_Query object if we don't pass any
+			 * arguments directly into the Post List component.
+			 */
+			$config['wp_query'] = ! empty( $config['query_args'] )
+				? get_wp_query_for_post_list( $config['query_args'] )
+				: $wp_query;
 
 			return $config;
 		},
@@ -139,6 +134,100 @@ register_component_from_config(
 		},
 	]
 );
+
+/**
+ * Wrapper for getting a new WP_Query object.
+ *
+ * This allows us to deduplicate posts returned by Post List components.
+ *
+ * @see https://docs.wpvip.com/technical-references/code-quality-and-best-practices/using-post__not_in/
+ *
+ * @param array $query_args Query args for a new WP_Query.
+ * @return WP_Query
+ */
+function get_wp_query_for_post_list( array $query_args ): WP_Query {
+
+	// Do not deduplicate the WP_Query.
+	if ( ! wp_validate_boolean( $query_args['exclude'] ?? false ) ) {
+		return new WP_Query( $query_args );
+	}
+
+	// Ensure we have a value for `posts_per_page`.
+	if ( ! isset( $query_args['posts_per_page'] ) ) {
+		$query_args['posts_per_page'] = get_option( 'posts_per_page', 10 );
+	}
+
+	$number_of_posts_to_return = -1;
+
+	/**
+	 * If `posts_per_page` is a valid integer above 0, increase the requested
+	 * total by the number of post IDs already used.
+	 */
+	if (
+		is_int( $query_args['posts_per_page'] )
+		&& $query_args['posts_per_page'] > 0
+	) {
+
+		// Remember the original number of posts to return.
+		$number_of_posts_to_return = $query_args['posts_per_page'];
+
+		// Increase our query by the number of posts already used, ensuring we
+		// can deduplicate and still meet our original `posts_per_page` value.
+		$query_args['posts_per_page'] = $number_of_posts_to_return + count( post_list_get_and_add_used_post_ids() );
+	}
+
+	// Get the new query.
+	$query = new WP_Query( $query_args );
+
+	// No valid results found anyway.
+	if ( ! $query->have_posts() ) {
+		return $query;
+	}
+
+	return deduplicate_query( $query, $number_of_posts_to_return );
+}
+
+/**
+ * Remove any posts from a WP_Query object that have already been used
+ *
+ * @param WP_Query $query           Query object to deduplicate against.
+ * @param int      $posts_to_return Max number of posts to return.
+ * @return WP_Query
+ */
+function deduplicate_query( WP_Query $query, int $posts_to_return ): WP_Query {
+
+	// Keep track of new posts.
+	$deduplicated_posts = [];
+
+	// Grab already used posts.
+	$used_posts = post_list_get_and_add_used_post_ids();
+
+	// Loop through each post and remove if we've already used it.
+	foreach ( $query->posts as $post ) {
+
+		// Handle both WP_Post objects, and post IDs when only fetching IDs.
+		$post_id = $post->ID ?? $post;
+
+		// If this post hasn't been used already.
+		if ( ! in_array( $post_id, $used_posts, true ) ) {
+			$deduplicated_posts[] = $post;
+		}
+
+		// Once we hit our number of posts to return, exit the loop.
+		if ( count( $deduplicated_posts ) >= $posts_to_return ) {
+			break;
+		}
+	}
+
+	// Update WP_Query to only include deduplicated posts, and reset the
+	// indexes.
+	$query->posts = array_values( $deduplicated_posts );
+
+	// Update our count to reflect the change.
+	$query->post_count = count( $query->posts );
+
+	return $query;
+}
 
 /**
  * Keep track of used post IDs to de-duplicate with `post__not_in`.

--- a/inc/components/components/post-list/component.php
+++ b/inc/components/components/post-list/component.php
@@ -214,7 +214,10 @@ function deduplicate_query( WP_Query $query, int $posts_to_return ): WP_Query {
 		}
 
 		// Once we hit our number of posts to return, exit the loop.
-		if ( count( $deduplicated_posts ) >= $posts_to_return ) {
+		if (
+			$posts_to_return >= 0
+			&& count( $deduplicated_posts ) >= $posts_to_return
+		) {
 			break;
 		}
 	}


### PR DESCRIPTION
## Summary
As titled.

## Notes for reviewers
Docs on why and how are here, https://docs.wpvip.com/technical-references/code-quality-and-best-practices/using-post__not_in/

## Changelog entries
* **Changed**: Refactor `irving/post-list` to not use `post__not_in` for deduplication purposes.

## Ticket(s)
https://alleyinteractive.atlassian.net/browse/IRV-1003