### PR TITLE
Improve Coral integration to account for permalink modifications

### DIFF
--- a/inc/components/components/coral/component.json
+++ b/inc/components/components/coral/component.json
@@ -5,6 +5,10 @@
         "embed_URL": {
           "default": "",
           "type": "string"
+        },
+        "story_id": {
+          "default": 0,
+          "type": "int"
         }
     }
 }

--- a/inc/components/components/coral/component.php
+++ b/inc/components/components/coral/component.php
@@ -22,6 +22,7 @@ register_component_from_config(
 				$config,
 				[
 					'embed_URL' => untrailingslashit( Integrations\get_option_value( 'coral', 'url' ) ),
+					'story_id'  => get_the_ID(),
 				]
 			);
 		},

--- a/inc/integrations/class-coral.php
+++ b/inc/integrations/class-coral.php
@@ -665,7 +665,7 @@ class Coral {
 		}
 
 		// Something else went wrong; email the result to the site admin.
-		wp_mail(
+		wp_mail( /* phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_mail_wp_mail */
 			get_option( 'admin_email' ),
 			__( 'Unsuccessful Coral Story URL Update', 'wp-irving' ),
 			sprintf(

--- a/inc/integrations/class-coral.php
+++ b/inc/integrations/class-coral.php
@@ -633,9 +633,9 @@ class Coral {
 	 * Pass along the updated permalink to Coral so that the post continues to
 	 * be properly identified.
 	 *
-	 * @param int    $meta_id     ID of updated metadata entry.
-	 * @param int    $object_id   ID of the object metadata is for.
-	 * @param string $meta_key    Metadata key.
+	 * @param int    $meta_id   ID of updated metadata entry.
+	 * @param int    $object_id ID of the object metadata is for.
+	 * @param string $meta_key  Metadata key.
 	 */
 	public function check_for_updated_permalink( $meta_id, $object_id, $meta_key ) {
 		// Verify the meta key.

--- a/inc/integrations/class-pico.php
+++ b/inc/integrations/class-pico.php
@@ -144,14 +144,14 @@ class Pico {
 	}
 
 	/**
-	 * Render an input for the Pico Whitelisted SSO Tiers.
+	 * Render a textarea for the Pico allow listed SSO Tiers.
 	 */
 	public function render_pico_tiers_input() {
 		// Check to see if there are existing tiers in the option.
 		$tiers = $this->options[ $this->option_key ]['tiers'] ?? '';
 
 		?>
-			<input id="pico_tiers" type="text" name="irving_integrations[<?php echo esc_attr( 'pico_tiers' ); ?>]" value="<?php echo esc_attr( $tiers ); ?>" />
+			<textarea id="pico_tiers" rows="5" cols="50" type="text" name="irving_integrations[<?php echo esc_attr( 'pico_tiers' ); ?>]"><?php echo esc_attr( $tiers ); ?></textarea>
 			<label for="pico_tiers">
 				<p>
 					<em><?php echo esc_html__( 'Tiers should be input as comma-separated values (e.g. Reader,Subscriber)', 'wp-irving' ); ?></em>

--- a/inc/integrations/class-pico.php
+++ b/inc/integrations/class-pico.php
@@ -194,7 +194,7 @@ class Pico {
 		$tiers = Integrations\get_option_value( 'pico', 'tiers' );
 
 		if ( ! empty( $tiers ) ) {
-			$options['pico']['tiers'] = explode( ',', $tiers );
+			$options['pico']['tiers'] = array_filter( array_map( 'trim', explode( ',', $tiers ) ) );
 		}
 
 		/**

--- a/tests/components/test-components.php
+++ b/tests/components/test-components.php
@@ -1714,6 +1714,7 @@ class Test_Components extends WP_UnitTestCase {
 			[
 				'config' => [
 					'embedUrl' => 'https://example.coral.test',
+					'storyId'  => 0,
 				],
 			]
 		);


### PR DESCRIPTION
Currently, if a post's permalink is changed, a new Coral commenting thread is created because Coral is using the post's permalink as the only unique identifier. This PR:

* Explicitly passes the post ID in the Coral embed as the unique story identifier
* Updates story metadata in Coral when the permalink is changed

These changes ensure the existing commenting thread is used on a post with a modified permalink.