### PR TITLE
Only send Story ID for published posts

### DIFF
--- a/inc/components/components/coral/component.php
+++ b/inc/components/components/coral/component.php
@@ -22,7 +22,7 @@ register_component_from_config(
 				$config,
 				[
 					'embed_URL' => untrailingslashit( Integrations\get_option_value( 'coral', 'url' ) ),
-					'story_id'  => get_the_ID(),
+					'story_id'  => 'publish' === get_post_status() ? get_the_ID() : null,
 				]
 			);
 		},


### PR DESCRIPTION
Sending the story ID for a Coral embed on post previews causes issues