### PR TITLE
Add support for additional Coral config and account for API fetch limit of 25

### DIFF
--- a/inc/components/components/coral-comment-count-static/component.json
+++ b/inc/components/components/coral-comment-count-static/component.json
@@ -2,6 +2,10 @@
   "name": "irving/coral-comment-count-static",
   "description": "Coral comment count that is fetched from post meta.",
   "config": {
+    "article_URL": {
+      "default": "",
+      "type": "string"
+    },
     "class_name": {
       "default": "coral-count",
       "type": "string"
@@ -13,6 +17,10 @@
     "count_text": {
       "default": "Comments",
       "type": "string"
+    },
+    "no_text": {
+      "default": false,
+      "type": "bool"
     },
     "post_id": {
       "default": 0,

--- a/inc/components/components/coral-comment-count-static/component.php
+++ b/inc/components/components/coral-comment-count-static/component.php
@@ -28,6 +28,9 @@ register_component_from_config(
 				$config['count_text'] = __( 'Comment', 'wp-irving' );
 			}
 
+			// Set the article URL.
+			$config['article_URL'] = get_the_permalink( $config['post_id'] );
+
 			return $config;
 		},
 	]


### PR DESCRIPTION
This PR:
* Adds `article_URL` and `no_text` config to achieve parity with original Coral component (see companion PR: https://github.com/alleyinteractive/irving/pull/590)
* Fixes the logic for the cron API calls. Previously I had assumed requesting more stories than were available was causing the Internal Error response, but after additional testing I realized the limit is 25 (this is undocumented), regardless of how many stories are available. So now we'll request all stories on the first run, then the 25 most recently active every 15 minutes, and if more than 25 were active in those 15 minutes, perform another full story fetch. Not the most ideal, but also probably unlikely to happen that often.