### PR TITLE
Release 0.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ While WP Irving contains a few basic plugin integrations (and we hope to support
 
 ## Changelog ##
 
+### 0.11.0 ###
+
+* Fix: Allow filter to handle generic objects instead of WP_Term objects (#340)
+* Add: Ability to fetch Coral comment counts for posts via cron and related component (#341)
+* Add: Support for additional Coral config and account for API fetch limit of 25 (#342)
+* Fix: Only update story URL in Coral for posts (#343)
+
 ### 0.10.0 ###
 
 * Fix: Handle question mark edge case in usernames (#333)

--- a/readme.txt
+++ b/readme.txt
@@ -19,6 +19,13 @@ While WP Irving contains a few basic plugin integrations (and we hope to support
 
 == Changelog ==
 
+= 0.11.0 =
+
+* Fix: Allow filter to handle generic objects instead of WP_Term objects (#340)
+* Add: Ability to fetch Coral comment counts for posts via cron and related component (#341)
+* Add: Support for additional Coral config and account for API fetch limit of 25 (#342)
+* Fix: Only update story URL in Coral for posts (#343)
+
 = 0.10.0 =
 
 * Fix: Handle question mark edge case in usernames (#333)

--- a/wp-irving.php
+++ b/wp-irving.php
@@ -6,7 +6,7 @@
  * Author URI:      https://alley.co
  * Text Domain:     wp-irving
  * Domain Path:     /languages
- * Version:         0.10.0
+ * Version:         0.11.0
  *
  * @package         WP_Irving
  */


### PR DESCRIPTION
## Summary
Releases WP Irving 0.11.0.

## Changelog
* Fix: Allow filter to handle generic objects instead of WP_Term objects (#340)
* Add: Ability to fetch Coral comment counts for posts via cron and related component (#341)
* Add: Support for additional Coral config and account for API fetch limit of 25 (#342)
* Fix: Only update story URL in Coral for posts (#343)
