### PR TITLE
Handle is_home when a page is used

### DIFF
--- a/inc/endpoints/class-components-endpoint.php
+++ b/inc/endpoints/class-components-endpoint.php
@@ -404,6 +404,11 @@ class Components_Endpoint extends Endpoint {
 		$wp->handle_404();
 		$wp->register_globals();
 
+		// Handle the homepage being set to a page.
+		if ( $wp_query->get( 'page_id' ) === get_option( 'page_on_front' ) ) {
+			$wp_query->is_home = true;
+		}
+
 		return $wp_query;
 	}
 


### PR DESCRIPTION
## Summary
As titled.

## Notes for reviewers
None.

## Changelog entries
* **Fixed**: Added support for `is_home` on the `WP_Query` global when a page is set as the homepage.

## Ticket(s)
None.