### PR TITLE
Add coral comment count threshold setting

### DIFF
--- a/inc/integrations/class-coral.php
+++ b/inc/integrations/class-coral.php
@@ -138,6 +138,14 @@ class Coral {
 		);
 
 		add_settings_field(
+			'wp_irving_coral_comment_count_display_threshold',
+			esc_html__( 'Minimum number of comments required to display the comment count', 'wp-irving' ),
+			[ $this, 'render_coral_comment_count_display_threshold_input' ],
+			'wp_irving_integrations',
+			'irving_integrations_settings'
+		);
+
+		add_settings_field(
 			'wp_irving_coral_banned_names',
 			esc_html__( 'Coral Banned Username Values', 'wp-irving' ),
 			[ $this, 'render_coral_banned_usernames_textarea' ],
@@ -217,6 +225,18 @@ class Coral {
 
 		?>
 			<input type="checkbox" name="irving_integrations[<?php echo esc_attr( 'coral_use_cron' ); ?>]" value="true" <?php echo esc_attr( $is_checked ); ?> />
+		<?php
+	}
+
+	/**
+	 * Render a number input which determines when comment count icons appear.
+	 */
+	public function render_coral_comment_count_display_threshold_input() {
+		// Check to see if there is an existing SSO secret in the option.
+		$comment_count_display_threshold = $this->options[ $this->option_key ]['comment_count_display_threshold'] ?? 0;
+
+		?>
+			<input type="number" step="1" min="0" name="irving_integrations[<?php echo esc_attr( 'coral_comment_count_display_threshold' ); ?>]" value="<?php echo esc_attr( $comment_count_display_threshold ); ?>" />
 		<?php
 	}
 

--- a/inc/integrations/class-coral.php
+++ b/inc/integrations/class-coral.php
@@ -232,7 +232,7 @@ class Coral {
 	 * Render a number input which determines when comment count icons appear.
 	 */
 	public function render_coral_comment_count_display_threshold_input() {
-		// Check to see if there is an existing SSO secret in the option.
+		// Check to see if there is an existing value.
 		$comment_count_display_threshold = $this->options[ $this->option_key ]['comment_count_display_threshold'] ?? 0;
 
 		?>


### PR DESCRIPTION
## Summary
Introduces a new Coral integration field for comment count threshold.

## Notes for reviewers
By itself, this value doesn't do anything - it's up to individual projects to utilize it.

## Changelog entries
* **Added**: Number field in the Irving integrations for setting a Coral comment count icon threshold value.

## Ticket(s)
https://alleyinteractive.atlassian.net/browse/LEDE-1915