### PR TITLE
Check for auth before displaying admin bar

### DIFF
--- a/inc/templates/admin-bar.php
+++ b/inc/templates/admin-bar.php
@@ -74,7 +74,8 @@ function wp_head() {
 		? sanitize_text_field( wp_unslash( $_SERVER['HTTP_REFERER'] ) )
 		: '';
 
-	// Bail early if the request did not come from the home URL.
+	// Bail early if the request did not come from the home URL or user isn't
+	// authenticated.
 	if (
 		wp_parse_url( home_url(), PHP_URL_HOST ) !== wp_parse_url( $referer, PHP_URL_HOST )
 		|| ! is_user_logged_in()


### PR DESCRIPTION
## Summary
As titled.

## Notes for reviewers
None.

## Changelog entries
* **Fixed**: Ensure admin bar only renders for logged in users.

## Ticket(s)
https://alleyinteractive.atlassian.net/browse/LEDE-1848