### PR TITLE
use method_exists instead of is_callable to check for SRM

### DIFF
--- a/inc/integrations/class-safe-redirect-manager.php
+++ b/inc/integrations/class-safe-redirect-manager.php
@@ -35,7 +35,7 @@ class Safe_Redirect_Manager {
 	 */
 	public function setup() {
 		// Ensure Safe Redirect Manager exists and is enabled.
-		if ( ! is_callable( [ 'SRM_Redirect', 'match_redirect' ] ) ) {
+		if ( ! method_exists( 'SRM_Redirect', 'match_redirect' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
In PHP8 `is_callable` doesn't behave the same way we'd expect for our integrations functionality. This PR switches to using `method_exists` instead.