### PR TITLE
add missing variable declaration

### DIFF
--- a/inc/class-admin.php
+++ b/inc/class-admin.php
@@ -174,12 +174,16 @@ class Admin {
 			// Get term.
 			$term = get_term_by( 'term_taxonomy_id', $term_id, wp_unslash( $_GET['taxonomy'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
-			// Get term permalink.
-			$permalink = get_term_link( $term->term_id ?? 0 );
+			/**
+			 * Implementing the same fix from from the forked repo for the new tax edit page error.
+			 * https://github.com/alleyinteractive/wp-irving/blob/bc1efd287875e639e4a641a8ece0d1c5669be9c6/inc/templates/admin-bar.php#L325
+			*/
+			if ( $term instanceof \WP_Term ) {
 
-			// Get the API URL, allowing it to be filtered.
-			$path_url = \WP_Irving\REST_API\Components_Endpoint::get_wp_irving_api_url( $permalink );
-			$path_url = apply_filters( 'wp_irving_term_row_action_path_url', $path_url, $term );
+				// Get the API URL, allowing it to be filtered.
+				$path_url = \WP_Irving\REST_API\Components_Endpoint::get_wp_irving_api_url( get_term_link( $term->term_id ) );
+				$path_url = apply_filters( 'wp_irving_term_row_action_path_url', $path_url, $term );
+			}
 		}
 
 		if (

--- a/inc/endpoints/class-components-registry-endpoint.php
+++ b/inc/endpoints/class-components-registry-endpoint.php
@@ -22,10 +22,11 @@ class Components_Registry_Endpoint extends Endpoint {
 			self::get_namespace(),
 			'/registered-components/',
 			[
-				'methods'  => \WP_REST_Server::READABLE,
-				'callback' => function() {
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => function() {
 					return \WP_Irving\get_registry()->get_registered_components();
 				},
+				'permission_callback' => '__return_true',
 			]
 		);
 	}

--- a/inc/endpoints/class-data-endpoint.php
+++ b/inc/endpoints/class-data-endpoint.php
@@ -46,8 +46,9 @@ class Data_Endpoint extends Endpoint {
 				self::get_namespace(),
 				'/data/' . $endpoint['slug'],
 				[
-					'methods'  => \WP_REST_Server::READABLE,
-					'callback' => $endpoint['callback'],
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => $endpoint['callback'],
+					'permission_callback' => '__return_true',
 				]
 			);
 		}

--- a/inc/endpoints/class-form-endpoint.php
+++ b/inc/endpoints/class-form-endpoint.php
@@ -46,8 +46,9 @@ class Form_Endpoint extends Endpoint {
 				self::get_namespace(),
 				'/form/' . $endpoint['slug'],
 				[
-					'methods'  => \WP_REST_Server::CREATABLE,
-					'callback' => $endpoint['callback'],
+					'methods'             => \WP_REST_Server::CREATABLE,
+					'callback'            => $endpoint['callback'],
+					'permission_callback' => '__return_true',
 				]
 			);
 		}

--- a/inc/integrations/class-jwt-auth.php
+++ b/inc/integrations/class-jwt-auth.php
@@ -28,6 +28,13 @@ class JWT_Auth {
 	const KEYPAIR_NAME = 'wp-irving-jwt-auth';
 
 	/**
+	 * Cookie domain.
+	 *
+	 * @var string
+	 */
+	protected $cookie_domain;
+
+	/**
 	 * Class instance.
 	 *
 	 * @var null|self

--- a/inc/templates.php
+++ b/inc/templates.php
@@ -199,7 +199,7 @@ function filter_template_loader() {
  * @return string The path to the found template.
  */
 function locate_template( array $templates ): string {
-	$template_path = STYLESHEETPATH . '/templates/';
+	$template_path = get_stylesheet_directory() . '/templates/';
 
 	/**
 	 * Filter the path to Irving templates.
@@ -250,7 +250,7 @@ function locate_template( array $templates ): string {
  */
 function locate_template_part( string $template ): string {
 
-	$template_part_path = STYLESHEETPATH . '/template-parts/';
+	$template_part_path = get_stylesheet_directory() . '/template-parts/';
 
 	/**
 	 * Filter the path to Irving template partss.


### PR DESCRIPTION
The WP Irving plugin is showing an error:

```
PHP Deprecated:  Creation of dynamic property WP_Irving\JWT_Auth::$cookie_domain is deprecated in /wp/wp-content/client-mu-plugins/wp-irving/inc/integrations/class-jwt-auth.php on line 88
```

This is happening because the `WP_Irving\JWT_Auth` class does not declare the `$cookie_domain` variable before using it.

Not declaring this variable before it's used causes a 'dynamic variable' to be created, which is [deprecated in PHP 8.2](https://php.watch/versions/8.2/dynamic-properties-deprecated).

This PR fixes that by declaring the variable.